### PR TITLE
Use API for Peer Id

### DIFF
--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -18,7 +18,7 @@ import { useGuardianContext } from '../hooks';
 import { GuardianRole, Peer } from '../types';
 import { ReactComponent as ArrowRightIcon } from '../assets/svgs/arrow-right.svg';
 import { ReactComponent as CopyIcon } from '../assets/svgs/copy.svg';
-import { formatApiErrorMessage, getMyPeerId } from '../utils/api';
+import { formatApiErrorMessage } from '../utils/api';
 
 interface PeerWithHash {
   id: string;
@@ -53,6 +53,7 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
         const [
           {
             consensus: { peers },
+            our_current_id
           },
           hashes,
         ] = await Promise.all([
@@ -60,22 +61,15 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
           api.getVerifyConfigHash(),
         ]);
 
-        const myPeerId = getMyPeerId(peers);
-        if (!myPeerId) {
-          throw new Error(
-            'Unable to determine which peer you are. Please refresh and try again.'
-          );
-        }
-
-        setMyHash(hashes[myPeerId]);
+        setMyHash(hashes[our_current_id]);
         setPeersWithHash(
           Object.entries(peers)
             .map(([id, peer]) => ({
               id,
               peer,
-              hash: hashes[id],
+              hash: hashes[id as unknown as number],
             }))
-            .filter((peer) => peer.id !== myPeerId)
+            .filter((peer) => peer.id !== our_current_id.toString())
         );
       } catch (err) {
         setError(formatApiErrorMessage(err));

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -52,7 +52,7 @@ export interface BitcoinRpc {
   url: string;
 }
 
-export type PeerHashMap = Record<string, string>;
+export type PeerHashMap = Record<number, string>;
 
 export type LnFedimintModule = [
   'ln',
@@ -94,7 +94,7 @@ export type ConfigGenParams = {
 };
 
 type ConsensusParams = ConfigGenParams & {
-  peers: Record<string, Peer>;
+  peers: Record<number, Peer>;
 };
 
 export interface ConsensusState {

--- a/apps/guardian-ui/src/utils/api.ts
+++ b/apps/guardian-ui/src/utils/api.ts
@@ -1,5 +1,5 @@
 import { JsonRpcError } from 'jsonrpc-client-websocket';
-import { AnyFedimintModule, ConfigGenParams, Peer } from '../types';
+import { AnyFedimintModule, ConfigGenParams } from '../types';
 
 /**
  * Given a config and the name of the module, return the module
@@ -30,16 +30,4 @@ export function formatApiErrorMessage(err: unknown) {
     return (err as Error).message;
   }
   return (err as object).toString();
-}
-
-/**
- * Given a map of peers, determine which one is you.
- */
-export function getMyPeerId(peers: Record<string, Peer>) {
-  // TODO: Find a better way to do this than using env var?
-  const myApiUrl = new URL(process.env.REACT_APP_FM_CONFIG_API as string);
-  return Object.entries(peers).find((peer) => {
-    const apiUrl = new URL(peer[1].api_url);
-    return myApiUrl.origin === apiUrl.origin;
-  })?.[0];
 }


### PR DESCRIPTION
The api returns `our_current_id` for `get_verify_config_hash`, so we use that. Since PeerId is part of ConsensusConfigGenParams too, we can determine which peer we are/are not.