### PR TITLE
1 connectguardianstsx displays wrong value

### DIFF
--- a/apps/guardian-ui/src/GuardianContext.tsx
+++ b/apps/guardian-ui/src/GuardianContext.tsx
@@ -47,6 +47,7 @@ function makeInitialState(loadFromStorage = true): SetupState {
     numPeers: 0,
     peers: [],
     isSetupComplete: false,
+    ourCurrentId: null,
     ...storageState,
   };
 }
@@ -77,6 +78,8 @@ const reducer = (state: SetupState, action: SetupAction): SetupState => {
       return { ...state, peers: action.payload };
     case SETUP_ACTION_TYPE.SET_IS_SETUP_COMPLETE:
       return { ...state, isSetupComplete: action.payload };
+    case SETUP_ACTION_TYPE.SET_OUR_CURRENT_ID:
+      return { ...state, ourCurrentId: action.payload };
     default:
       return state;
   }
@@ -234,6 +237,10 @@ export const GuardianProvider: React.FC<GuardianProviderProps> = ({
   // Fetch consensus state, dispatch updates with it.
   const fetchConsensusState = useCallback(async () => {
     const consensusState = await api.getConsensusConfigGenParams();
+    dispatch({
+      type: SETUP_ACTION_TYPE.SET_OUR_CURRENT_ID,
+      payload: consensusState.our_current_id,
+    });
     dispatch({
       type: SETUP_ACTION_TYPE.SET_PEERS,
       payload: Object.values(consensusState.consensus.peers),

--- a/apps/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/apps/guardian-ui/src/components/ConnectGuardians.tsx
@@ -26,9 +26,11 @@ interface Props {
 
 export const ConnectGuardians: React.FC<Props> = ({ next }) => {
   const {
-    state: { role, peers, numPeers, configGenParams },
+    state: { role, peers, numPeers, configGenParams, ourCurrentId },
     api,
   } = useGuardianContext();
+
+  const guardianLink = ourCurrentId !== null ? peers[ourCurrentId].api_url : '';
 
   // Poll for peers and configGenParams while on this page.
   useConsensusPolling();
@@ -58,7 +60,7 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
       <FormControl maxWidth={400}>
         <FormLabel>Invite Followers</FormLabel>
         <CopyInput
-          value={process.env.REACT_APP_FM_CONFIG_API || ''}
+          value={guardianLink}
           size='lg'
           buttonLeftIcon={<Icon as={CopyIcon} />}
         />

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -138,6 +138,7 @@ export interface SetupState {
   progress: SetupProgress;
   myName: string;
   password: string;
+  ourCurrentId: number | null;
   configGenParams: ConfigGenParams | null;
   numPeers: number;
   needsAuth: boolean;
@@ -157,6 +158,7 @@ export enum SETUP_ACTION_TYPE {
   SET_NUM_PEERS = 'SET_NUM_PEERS',
   SET_PEERS = 'SET_PEERS',
   SET_IS_SETUP_COMPLETE = 'SET_IS_SETUP_COMPLETE',
+  SET_OUR_CURRENT_ID = 'SET_OUR_CURRENT_ID',
 }
 
 export type SetupAction =
@@ -203,4 +205,8 @@ export type SetupAction =
   | {
       type: SETUP_ACTION_TYPE.SET_IS_SETUP_COMPLETE;
       payload: boolean;
+    }
+  | {
+      type: SETUP_ACTION_TYPE.SET_OUR_CURRENT_ID;
+      payload: number;
     };


### PR DESCRIPTION
Saves `our_current_id` from the API to GuardianContext. 
Then uses that to filter and display `api_url` from `peers`.

Previously, it was displaying the url from the ENV VAR `REACT_APP_FM_CONFIG_API` which may not always be the same.