### PR TITLE
build: iterate mprocs definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,16 @@ After running through the config setup UI flow once, you will need to delete the
 ### Running with mprocs
 
 1. Install [mprocs](https://github.com/pvolok/mprocs)
-1. Run `mprocs -c mprocs.yml` 
+1. Run `mprocs -c mprocs.yml`
 
 After running this command, you'll be present with the mprocs display. Along the left side are the list of processes currently available by mprocs. Along the bottom are hotkeys for navigating/interacting with mprocs. The main pane shows the shell output for the currently selected process.
 
-The `run-ui-federation` process shows combined logging for `fedimintd`, `bitcoind`, `gatewayd`, and `lnd`.
+The `start-servers` process shows combined logging for `fedimintd`, `bitcoind`, `gatewayd`, and `lnd`.
 
-The `teardown-ui-federation` process can be used to stop all docker containers by hitting the `s` key to start the process. After doing so, you can return to the `run-ui-federation` process and hit `r` to restart things.
+The `stop-servers` process can be used to stop all docker containers by hitting the `s` key to start the process. After doing so, you can return to the `start-servers` process and hit `r` to restart things.
 
-The `coordinator` and `guardian1` are instances of `guardian-ui` running on different ports and connected to different `fedimintd` instances (running in the `run-ui-federation` process).
+The `guardian-ui-1` and `guardian-ui-2` are instances of `guardian-ui` apps, each running on different ports and connected to a unique `fedimintd` server instance (running in the `start-servers` process).
 
-You can see more details by viewing the `mprocs.yml` file. 
+The `gateway-ui` is an instance of `gateway-ui` app, connected to a `gatewayd` server instance (running in the `start-servers` process).
+
+You can see more details by viewing the `mprocs.yml` file.

--- a/mprocs.yml
+++ b/mprocs.yml
@@ -1,23 +1,27 @@
 procs:
-  run-ui-federation:
+  start-servers:
     shell: docker compose up
-  teardown-ui-federation:
-    shell: docker compose down
+  stop-servers:
+    shell: docker compose down && echo 'Removing fm dirs' && sudo rm -rf fm_* && echo 'Done'
     autostart: false
-  coordinator:
+  guardian-ui-1:
     cwd: apps/guardian-ui/
     shell: yarn dev
     env:
       PORT: '3000'
       REACT_APP_FM_CONFIG_API: ws://127.0.0.1:18174
       BROWSER: none
-  guardian1:
+  guardian-ui-2:
     cwd: apps/guardian-ui/
     shell: yarn dev
     env:
       PORT: '3001'
       REACT_APP_FM_CONFIG_API: ws://127.0.0.1:18184
       BROWSER: none
-  clear-federation-data:
-    shell: rm -rf fm_*
-    autostart: false
+  gateway-ui:
+    cwd: apps/gateway-ui/
+    shell: yarn dev
+    env:
+      PORT: '3002'
+      REACT_APP_FM_GATEWAY_API: 'http://127.0.0.1:8175'
+      BROWSER: none


### PR DESCRIPTION
Tried to use mprocs for dev and realized
1. I need `clear-federation-data` and `teardown-ui-federation` to be in the same process so I don't clear data without teardown
2. I need sudo to remove `fm_*` dirs

Refactored this definition and ended with this mprocs def.

Also runs a gateway-ui instance
![image](https://github.com/fedimint/ui/assets/11217077/70122ae7-034c-472e-96ac-4396a0152c03)