### PR TITLE
build: adds additional mprocs processes

### DIFF
--- a/mprocs.yml
+++ b/mprocs.yml
@@ -1,8 +1,11 @@
 procs:
   start-servers:
     shell: docker compose up
-  stop-servers:
+  stop-servers-clear-data:
     shell: docker compose down && echo 'Removing fm dirs' && sudo rm -rf fm_* && echo 'Done'
+    autostart: false
+  stop-servers-retain-data:
+    shell: docker compose down
     autostart: false
   guardian-ui-1:
     cwd: apps/guardian-ui/
@@ -25,3 +28,7 @@ procs:
       PORT: '3002'
       REACT_APP_FM_GATEWAY_API: 'http://127.0.0.1:8175'
       BROWSER: none
+  fedimintd_1-logs:
+    shell: sleep 3 && docker logs -f ui-fedimintd_1-1
+  fedimintd_2-logs:
+    shell: sleep 3 && docker logs -f ui-fedimintd_2-1


### PR DESCRIPTION
Adds an option to retain data when stopping fedimintd servers.
Adds an options for logs from only a sinlge fedimintd instance for better organization/debugging.