### PR TITLE
Config and List Gateways API

### DIFF
--- a/apps/gateway-ui/src/types.tsx
+++ b/apps/gateway-ui/src/types.tsx
@@ -8,8 +8,11 @@ export interface Registration {
   fees: Fees;
   mint_channel_id: number;
   node_pub_key: string;
-  route_hints: object[]; // FIXME
-  valid_until: object; // FIXME
+  route_hints: object[]; // FIXME : https://github.com/fedimint/ui/issues/80
+  valid_until: {
+    nanos_since_epoch: number;
+    secs_since_epoch: number;
+  };
 }
 
 export interface Federation {

--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -1,6 +1,7 @@
 import { JsonRpcError, JsonRpcWebsocket } from 'jsonrpc-client-websocket';
 import { ConfigGenParams, ConsensusState, PeerHashMap } from './setup/types';
 import {
+  ConfigResponse,
   ConsensusStatus,
   ServerStatus,
   StatusResponse,
@@ -20,7 +21,7 @@ export interface SocketAndAuthInterface {
 interface RpcInterface {
   call: <T>(
     method: SetupRpc | AdminRpc | SharedRpc,
-    params?: object | null
+    params?: unknown
   ) => Promise<T>;
   // TODO: Consider moving this to `SocketAndAuthInterface` as part of the authentication methods.
   clearPassword: () => void;
@@ -130,7 +131,7 @@ class BaseGuardianApi
 
   call = async <T>(
     method: SetupRpc | AdminRpc | SharedRpc,
-    params: object | null = null
+    params: unknown = null
   ): Promise<T> => {
     try {
       const websocket = await this.connect();
@@ -191,12 +192,14 @@ enum AdminRpc {
   fetchEpochCount = 'fetch_epoch_count',
   consensusStatus = 'consensus_status',
   connectionCode = 'connection_code',
+  config = 'config',
 }
 
 export interface AdminApiInterface extends SharedApiInterface {
   version: () => Promise<Versions>;
   fetchEpochCount: () => Promise<number>;
   connectionCode: () => Promise<string>;
+  config: (connection: string) => Promise<ConfigResponse>;
 }
 
 export class GuardianApi
@@ -331,5 +334,9 @@ export class GuardianApi
 
   connectionCode = (): Promise<string> => {
     return this.base.call(AdminRpc.connectionCode);
+  };
+
+  config = (connection: string): Promise<ConfigResponse> => {
+    return this.base.call<ConfigResponse>(AdminRpc.config, connection);
   };
 }

--- a/apps/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/apps/guardian-ui/src/components/ConnectGuardians.tsx
@@ -16,7 +16,7 @@ import {
 } from '@chakra-ui/react';
 import { CopyInput, Table, TableRow } from '@fedimint/ui';
 import { useConsensusPolling, useSetupContext } from '../hooks';
-import { ServerStatus } from '../types';
+import { ModuleKind, ServerStatus } from '../types';
 import { GuardianRole } from '../setup/types';
 import { getModuleParamsFromConfig } from '../utils/api';
 import { ReactComponent as CopyIcon } from '../assets/svgs/copy.svg';
@@ -79,13 +79,13 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
       },
       {
         label: 'Network',
-        value: getModuleParamsFromConfig(configGenParams, 'wallet')?.consensus
-          ?.network,
+        value: getModuleParamsFromConfig(configGenParams, ModuleKind.Wallet)
+          ?.consensus?.network,
       },
       {
         label: 'Block confirmations',
-        value: getModuleParamsFromConfig(configGenParams, 'wallet')?.consensus
-          ?.finality_delay,
+        value: getModuleParamsFromConfig(configGenParams, ModuleKind.Wallet)
+          ?.consensus?.finality_delay,
       },
     ];
 

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -29,6 +29,7 @@ import { ReactComponent as FedimintLogo } from '../assets/svgs/fedimint.svg';
 import { ReactComponent as BitcoinLogo } from '../assets/svgs/bitcoin.svg';
 import { ReactComponent as ArrowRightIcon } from '../assets/svgs/arrow-right.svg';
 import { formatApiErrorMessage, getModuleParamsFromConfig } from '../utils/api';
+import { ModuleKind } from '../types';
 
 interface Props {
   next: () => void;
@@ -69,11 +70,11 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
       setFederationName(params.meta?.federation_name || '');
 
       setMintAmounts(
-        getModuleParamsFromConfig(params, 'mint')?.consensus?.mint_amounts ||
-          mintAmounts
+        getModuleParamsFromConfig(params, ModuleKind.Mint)?.consensus
+          ?.mint_amounts || mintAmounts
       );
 
-      const walletModule = getModuleParamsFromConfig(params, 'wallet');
+      const walletModule = getModuleParamsFromConfig(params, ModuleKind.Wallet);
 
       if (walletModule) {
         setBlockConfirmations(

--- a/apps/guardian-ui/src/setup/types.tsx
+++ b/apps/guardian-ui/src/setup/types.tsx
@@ -1,4 +1,4 @@
-import { ServerStatus } from '../types';
+import { MetaConfig, ModuleKind, ServerStatus } from '../types';
 
 export enum GuardianRole {
   Host = 'Host',
@@ -42,22 +42,22 @@ export interface BitcoinRpc {
 
 export type PeerHashMap = Record<number, string>;
 
-export type LnFedimintModule = [
-  'ln',
+export type LnModuleParams = [
+  ModuleKind.Ln,
   {
     consensus?: object;
     local?: object;
   }
 ];
-export type MintFedimintModule = [
-  'mint',
+export type MintModuleParams = [
+  ModuleKind.Mint,
   {
     consensus?: { mint_amounts: number[] };
     local?: object;
   }
 ];
-export type WalletFedimintModule = [
-  'wallet',
+export type WalletModuleParams = [
+  ModuleKind.Wallet,
   {
     consensus?: { finality_delay: number; network: Network };
     local?: {
@@ -65,20 +65,16 @@ export type WalletFedimintModule = [
     };
   }
 ];
-export type OtherFedimintModule = [string, object];
-export type AnyFedimintModule =
-  | LnFedimintModule
-  | MintFedimintModule
-  | WalletFedimintModule
-  | OtherFedimintModule;
-
-type Meta = { federation_name?: string };
-
-type Modules = Record<number, AnyFedimintModule>;
+export type OtherModuleParams = [string, object];
+export type AnyModuleParams =
+  | LnModuleParams
+  | MintModuleParams
+  | WalletModuleParams
+  | OtherModuleParams;
 
 export type ConfigGenParams = {
-  meta: Meta;
-  modules: Modules;
+  meta: MetaConfig;
+  modules: Record<number, AnyModuleParams>;
 };
 
 type ConsensusParams = ConfigGenParams & {

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -78,3 +78,22 @@ export interface ClientConfig {
 export interface ConfigResponse {
   client_config: ClientConfig;
 }
+
+// These types are shared with the gateway-ui
+export interface Fees {
+  base_msat: number;
+  proportional_millionths: number;
+}
+
+export interface Gateway {
+  gateway_pub_key: string;
+  api: string;
+  fees: Fees;
+  mint_channel_id: number;
+  node_pub_key: string;
+  route_hints: object[]; // FIXME: https://github.com/fedimint/ui/issues/80
+  valid_until: {
+    nanos_since_epoch: number;
+    secs_since_epoch: number;
+  };
+}

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -47,3 +47,34 @@ export interface Versions {
     }
   >;
 }
+
+export enum ModuleKind {
+  Ln = 'ln',
+  Mint = 'mint',
+  Wallet = 'wallet',
+}
+
+interface FedimintModule {
+  config: string;
+  kind: ModuleKind;
+  version: number;
+}
+
+interface ApiEndpoint {
+  name: string;
+  url: string;
+}
+
+export type MetaConfig = { federation_name?: string };
+
+export interface ClientConfig {
+  consenus_version: number;
+  epoch_pk: string;
+  federation_id: string;
+  api_endpoint: Record<number, ApiEndpoint>;
+  modules: Record<number, FedimintModule>;
+  meta: MetaConfig;
+}
+export interface ConfigResponse {
+  client_config: ClientConfig;
+}

--- a/apps/guardian-ui/src/utils/api.ts
+++ b/apps/guardian-ui/src/utils/api.ts
@@ -1,15 +1,15 @@
 import { JsonRpcError } from 'jsonrpc-client-websocket';
-import { AnyFedimintModule, ConfigGenParams } from '../setup/types';
+import { AnyModuleParams, ConfigGenParams } from '../setup/types';
 
 /**
  * Given a config and the name of the module, return the module
  */
-export function getModuleParamsFromConfig<T extends AnyFedimintModule[0]>(
+export function getModuleParamsFromConfig<T extends AnyModuleParams[0]>(
   config: ConfigGenParams | null,
   moduleName: T
   // Ignore any type below, it will be properly typed at call time via moduleName.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Extract<AnyFedimintModule, [T, any]>[1] | null {
+): Extract<AnyModuleParams, [T, any]>[1] | null {
   if (!config) return null;
   const module = Object.values(config.modules).find((m) => m[0] === moduleName);
   return module ? module[1] : null;


### PR DESCRIPTION
Adds admin apis for fetching client config and listing registered gateways.
- To fetch config, we need connection string
```ts
  const [config, setConfig] = useState<ConfigResponse>();
  api.config(connectionCode).then(setConfig).catch(console.error);
```

- To list gateways, we need config, from which we can determine the lightning module id
```ts
  const [gateways, setGateways] = useState<object>(['foo']);
  if (config) {
      for (const [key, val] of Object.entries(config.client_config.modules)) {
        if (val.kind === 'ln') {
          api
            .moduleApiCall<Gateway[]>(key, LightningModuleRpc.listGateways)
            .then(setGateways)
            .catch(console.error);
          return;
        }
      }
    }
```