### PR TITLE
ci: build arm64 images in addition to amd64

### DIFF
--- a/.github/workflows/gateway-ui.yml
+++ b/.github/workflows/gateway-ui.yml
@@ -29,3 +29,4 @@ jobs:
           file: Dockerfile.gateway-ui
           push: ${{ github.ref == 'refs/heads/master' }}
           tags: fedimintui/gateway-ui:latest
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/gateway-ui.yml
+++ b/.github/workflows/gateway-ui.yml
@@ -29,4 +29,4 @@ jobs:
           file: Dockerfile.gateway-ui
           push: ${{ github.ref == 'refs/heads/master' }}
           tags: fedimintui/gateway-ui:latest
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.ref == 'refs/heads/master' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}

--- a/.github/workflows/guardian-ui.yml
+++ b/.github/workflows/guardian-ui.yml
@@ -28,3 +28,4 @@ jobs:
           file: Dockerfile.guardian-ui
           push: ${{ github.ref == 'refs/heads/master' }}
           tags: fedimintui/guardian-ui:latest
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/guardian-ui.yml
+++ b/.github/workflows/guardian-ui.yml
@@ -28,4 +28,4 @@ jobs:
           file: Dockerfile.guardian-ui
           push: ${{ github.ref == 'refs/heads/master' }}
           tags: fedimintui/guardian-ui:latest
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.ref == 'refs/heads/master' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}


### PR DESCRIPTION
I was getting the following error when trying to use the `docker-compose.yml` in `fedimint/docker`:
```
❯ docker-compose up
[+] Running 0/1
 ⠹ guardian-ui Pulling
no matching manifest for linux/arm64/v8 in the manifest list entries
```
This should provide an arm64 image. We may need to add more in the future if people run into this issue, but this should cover most of us for now.