### PR TITLE
Misc. dev call fixes

### DIFF
--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -60,7 +60,7 @@ class BaseGuardianApi
         throw new Error('REACT_APP_FM_CONFIG_API not set');
       }
 
-      const requestTimeoutMs = 20000;
+      const requestTimeoutMs = 1000 * 60 * 60 * 5; // 5 minutes, dkg can take a while
       const websocket = new JsonRpcWebsocket(
         websocketUrl,
         requestTimeoutMs,

--- a/apps/guardian-ui/src/setup/SetupContext.tsx
+++ b/apps/guardian-ui/src/setup/SetupContext.tsx
@@ -211,6 +211,12 @@ export const SetupContextProvider: React.FC<SetupContextProviderProps> = ({
     };
   }, [api]);
 
+  // Attach the API to the window for debugging purposes.
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).fedimintApi = api;
+  }, [api]);
+
   // Update local storage on state changes.
   useEffect(() => {
     localStorage.setItem(


### PR DESCRIPTION
* Expose the api to the window as `window.fedimintApi` for debugging purposes
* Increase RPC timeout to 5 minutes to allow for longer dkg