### PR TITLE
Fix fallback language

### DIFF
--- a/apps/gateway-ui/src/components/WithdrawTab.tsx
+++ b/apps/gateway-ui/src/components/WithdrawTab.tsx
@@ -92,7 +92,7 @@ export const WithdrawTab = React.memo(function WithdrawTab({
         setWithdrawObject({ ...withdrawObject, amount: 0, address: '' });
         setModalState(false);
       })
-      .catch(({ message, error }) => {
+      .catch(({ error }) => {
         console.error(error);
         setError(`${t('withdraw_tab.error_request')}`);
       });

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -19,7 +19,6 @@ import { ConnectGuardians } from '../components/ConnectGuardians';
 import { RunDKG } from '../components/RunDKG';
 import { VerifyGuardians } from '../components/VerifyGuardians';
 import { SetupComplete } from '../components/SetupComplete';
-import { SetupProgress as SetupStepper } from '../components/SetupProgress';
 import { useTranslation } from '@fedimint/utils';
 
 const PROGRESS_ORDER: SetupProgress[] = [

--- a/packages/utils/src/i18n.tsx
+++ b/packages/utils/src/i18n.tsx
@@ -1,21 +1,24 @@
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
-import { useTranslation } from 'react-i18next';
+export { useTranslation } from 'react-i18next';
 
-export const i18nProvider = (namespace: Array<any>) => {
-  const resources = namespace.reduce((acc, lng) => {
-    return {
-      ...acc,
-      [lng['key']]: { translation: lng['translation'] },
-    };
-  }, {});
+type Language = { key: string; description: string; translation: object };
+
+export const i18nProvider = (namespace: Language[]) => {
+  const resources = namespace.reduce(
+    (acc, { key, translation, description }) => {
+      return {
+        ...acc,
+        [key]: { translation, description },
+      };
+    },
+    {}
+  );
 
   i18n.use(LanguageDetector).use(initReactI18next).init({
     debug: true,
     resources,
     fallbackLng: 'en-US',
-  })
+  });
 };
-
-export { useTranslation };

--- a/packages/utils/src/i18n.tsx
+++ b/packages/utils/src/i18n.tsx
@@ -14,8 +14,8 @@ export const i18nProvider = (namespace: Array<any>) => {
   i18n.use(LanguageDetector).use(initReactI18next).init({
     debug: true,
     resources,
-    fallbackLng: 'en',
-  });
+    fallbackLng: 'en-US',
+  })
 };
 
 export { useTranslation };


### PR DESCRIPTION
The fallback language should be `en-US`, instead of `en`. And other clean ups