### PR TITLE
feat: wait for all guardians to verify configs before start consensus

### DIFF
--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -176,6 +176,7 @@ enum SetupRpc {
   setConfigGenParams = 'set_config_gen_params',
   getVerifyConfigHash = 'get_verify_config_hash',
   runDkg = 'run_dkg',
+  verifiedConfigs = 'verified_configs',
   startConsensus = 'start_consensus',
 }
 
@@ -190,6 +191,7 @@ export interface SetupApiInterface extends SharedApiInterface {
   setConfigGenParams: (params: ConfigGenParams) => Promise<void>;
   getVerifyConfigHash: () => Promise<PeerHashMap>;
   runDkg: () => Promise<void>;
+  verifiedConfigs: () => Promise<void>;
   startConsensus: () => Promise<void>;
 }
 
@@ -288,6 +290,10 @@ export class GuardianApi
 
   runDkg = (): Promise<void> => {
     return this.base.call(SetupRpc.runDkg);
+  };
+
+  verifiedConfigs = (): Promise<void> => {
+    return this.base.call(SetupRpc.verifiedConfigs);
   };
 
   startConsensus = async (): Promise<void> => {

--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -12,6 +12,7 @@ import {
   Input,
   Tag,
   useTheme,
+  HStack,
 } from '@chakra-ui/react';
 import { CopyInput, FormGroup, Table } from '@fedimint/ui';
 import { useConsensusPolling, useSetupContext } from '../hooks';
@@ -203,18 +204,33 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
           columns={tableColumns}
           rows={tableRows}
         />
-        <div>
+        <HStack mt={4}>
           <Button
             isDisabled={!verifiedConfigs}
             isLoading={isStarting}
             onClick={verifiedConfigs ? handleNext : undefined}
             leftIcon={<Icon as={ArrowRightIcon} />}
-            mt={4}
           >
             {t('common.next')}
           </Button>
-        </div>
+          <WaitingForVerification verifiedConfigs={verifiedConfigs} />
+        </HStack>
       </VStack>
     );
   }
+};
+
+const WaitingForVerification: React.FC<{ verifiedConfigs: boolean }> = ({
+  verifiedConfigs,
+}) => {
+  const { t } = useTranslation();
+
+  return verifiedConfigs ? (
+    <Text>{t('verify_guardians.all_guardians_verified')}</Text>
+  ) : (
+    <>
+      <Spinner />
+      <Text>{t('verify_guardians.wait_all_guardians_verification')}</Text>
+    </>
+  );
 };

--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -90,11 +90,12 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
       peersWithHash.every(({ hash }, idx) => hash === enteredHashes[idx]);
 
     if (isAllValid) {
-      api.verifiedConfigs().catch((err) => {
-        setError(formatApiErrorMessage(err));
-      });
+      !verifiedConfigs &&
+        api.verifiedConfigs().catch((err) => {
+          setError(formatApiErrorMessage(err));
+        });
     }
-  }, [api, peersWithHash, enteredHashes]);
+  }, [api, peersWithHash, enteredHashes, verifiedConfigs]);
 
   const handleNext = useCallback(async () => {
     setIsStarting(true);

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -116,6 +116,8 @@
     "table_description": "Enter each Guardian’s verification codes below.",
     "table_column_name": "Name",
     "table_column_status": "Status",
-    "table_column_hash_input": "Paste verification code"
+    "table_column_hash_input": "Paste verification code",
+    "wait_all_guardians_verification": "Waiting for all Guardians to verify their codes",
+    "all_guardians_verified": "All Guardians have verified their codes"
   }
 }

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -4,6 +4,7 @@ export enum ServerStatus {
   ReadyForConfigGen = 'ReadyForConfigGen',
   ConfigGenFailed = 'ConfigGenFailed',
   VerifyingConfigs = 'VerifyingConfigs',
+  VerifiedConfigs = 'VerifiedConfigs',
   Upgrading = 'Upgrading',
   ConsensusRunning = 'ConsensusRunning',
 }

--- a/flake.lock
+++ b/flake.lock
@@ -102,17 +102,17 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1689631985,
-        "narHash": "sha256-UV71E8+/Qa1+7LLOzkhsUOZ7pxfYQq7u9iKCoveSCDQ=",
+        "lastModified": 1689944162,
+        "narHash": "sha256-eXLoB0G+r0/vNElgBPY85fulLAQlTMcSsUVbPc/PLXg=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "8864e239e539c716b4f970397f508598dbb1c383",
+        "rev": "39a6763c6ad755bf8cbc38cf010da71d193f9696",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "8864e239e539c716b4f970397f508598dbb1c383",
+        "rev": "39a6763c6ad755bf8cbc38cf010da71d193f9696",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      url = "github:fedimint/fedimint?rev=8864e239e539c716b4f970397f508598dbb1c383";
+      url = "github:fedimint/fedimint?rev=39a6763c6ad755bf8cbc38cf010da71d193f9696";
     };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:


### PR DESCRIPTION
https://github.com/fedimint/fedimint/pull/2807 adds `VerifiedConfigs` state to which all guardians should wait before proceeding to start consensus. This change progresses a guardian to this state, immediately they verify all peer configs, and starts watching other guardian servers for progress through the verification step.

- With the addition of https://github.com/fedimint/fedimint/pull/2808, Guardians can also safely reload the verify configs page to access and share their config code

![image](https://github.com/fedimint/ui/assets/11217077/041a63b4-dff1-4adc-ada2-e58b1b4d72e5)


fixes #14 