### PR TITLE
fix: re-introduce setup progress indicator

### DIFF
--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -9,6 +9,7 @@ import {
   Spinner,
 } from '@chakra-ui/react';
 import { ReactComponent as ArrowLeftIcon } from '../assets/svgs/arrow-left.svg';
+import { useTranslation } from '@fedimint/utils';
 import { Header } from '../components/Header';
 import { useSetupContext } from '../hooks';
 import { GuardianRole, SetupProgress, SETUP_ACTION_TYPE } from './types';
@@ -19,7 +20,7 @@ import { ConnectGuardians } from '../components/ConnectGuardians';
 import { RunDKG } from '../components/RunDKG';
 import { VerifyGuardians } from '../components/VerifyGuardians';
 import { SetupComplete } from '../components/SetupComplete';
-import { useTranslation } from '@fedimint/utils';
+import { SetupProgress as SetupStepper } from '../components/SetupProgress';
 
 const PROGRESS_ORDER: SetupProgress[] = [
   SetupProgress.Start,
@@ -111,6 +112,9 @@ export const FederationSetup: React.FC = () => {
   return (
     <VStack gap={8} align='start'>
       <Header />
+      {progressIdx === 0 || !progressIdx ? null : (
+        <SetupStepper setupProgress={progressIdx} isHost={isHost} />
+      )}
       <VStack align='start' gap={2}>
         {prevProgress && canGoBack && (
           <Button


### PR DESCRIPTION
Just realized we lost the setup progress indicator as [part of the very large change](https://github.com/fedimint/ui/pull/24/commits/bdf68e2d76fc0eedd3a045f0e10520fe0ff70d05#diff-7678898746f2fa77f54469178ef028a4dda9a5c6543ebac6e3cd465dadd26640) introducing translations. We need more acute reviews, and #5 should help flag this kind of experience regressions