### PR TITLE
Improve guardian ui boot experience

### DIFF
--- a/apps/guardian-ui/src/App.tsx
+++ b/apps/guardian-ui/src/App.tsx
@@ -11,54 +11,39 @@ import { useTranslation } from '@fedimint/utils';
 
 export const App = React.memo(function App() {
   const { t } = useTranslation();
-  const {
-    appState: { experience },
-    apiState: { connected: isConnected, error },
-    api,
-  } = useAppContext();
+  const { appState, appError, api } = useAppContext();
 
   const getAppContent = useCallback(() => {
-    let content: React.ReactNode = (
-      <Center>
-        <Box p={10}>
-          <Spinner size='xl' />
-        </Box>
-      </Center>
-    );
-
-    if (isConnected) {
-      if (error) {
-        content = (
+    switch (appState) {
+      case 'Loading':
+        return (
+          <Center p={12}>
+            <Spinner size='xl' />
+          </Center>
+        );
+      case 'Setup':
+        return (
+          <SetupContextProvider api={api}>
+            <Wrapper>
+              <FederationSetup />
+            </Wrapper>
+          </SetupContextProvider>
+        );
+      case 'Admin':
+        return (
+          <AdminContextProvider api={api}>
+            <FederationAdmin />
+          </AdminContextProvider>
+        );
+      case 'Error':
+        return (
           <VStack spacing={4}>
             <Heading size='md'>{t('common.error')}</Heading>
-            <Text>{error}</Text>
+            <Text>{appError}</Text>
           </VStack>
         );
-      } else {
-        switch (experience) {
-          case 'Setup':
-            content = (
-              <SetupContextProvider api={api}>
-                <Wrapper>
-                  <FederationSetup />
-                </Wrapper>
-              </SetupContextProvider>
-            );
-            break;
-          case 'Admin':
-            content = (
-              <AdminContextProvider api={api}>
-                <FederationAdmin />
-              </AdminContextProvider>
-            );
-            break;
-          // TODO: Add auth experience
-        }
-      }
     }
-
-    return content;
-  }, [experience, isConnected, error]);
+  }, [appState, appError, api]);
 
   return (
     <React.StrictMode>

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -1,13 +1,5 @@
 import React, { useCallback } from 'react';
-import {
-  Box,
-  Button,
-  Text,
-  Heading,
-  Icon,
-  VStack,
-  Spinner,
-} from '@chakra-ui/react';
+import { Box, Button, Text, Heading, Icon, VStack } from '@chakra-ui/react';
 import { ReactComponent as ArrowLeftIcon } from '../assets/svgs/arrow-left.svg';
 import { Header } from '../components/Header';
 import { useSetupContext } from '../hooks';
@@ -33,7 +25,7 @@ const PROGRESS_ORDER: SetupProgress[] = [
 export const FederationSetup: React.FC = () => {
   const { t } = useTranslation();
   const {
-    state: { progress, role, password, needsAuth, isInitializing },
+    state: { progress, role, password, needsAuth },
     dispatch,
   } = useSetupContext();
 
@@ -58,9 +50,7 @@ export const FederationSetup: React.FC = () => {
   let subtitle: React.ReactNode;
   let canGoBack = false;
   let content: React.ReactNode;
-  if (isInitializing) {
-    content = <Spinner />;
-  } else if (needsAuth && !password) {
+  if (needsAuth && !password) {
     title = t('setup.auth.title');
     subtitle = t('setup.auth.subtitle');
     content = <Login />;

--- a/apps/guardian-ui/src/setup/SetupContext.tsx
+++ b/apps/guardian-ui/src/setup/SetupContext.tsx
@@ -229,6 +229,14 @@ export const SetupContextProvider: React.FC<SetupContextProviderProps> = ({
         configGenParams: state.configGenParams,
       })
     );
+
+    return () => {
+      // Clear local storage on setup complete.
+      // This happens when we transition to admin experience.
+      if (state.progress === SetupProgress.SetupComplete) {
+        localStorage.removeItem(LOCAL_STORAGE_SETUP_KEY);
+      }
+    };
   }, [
     state.role,
     state.progress,

--- a/apps/guardian-ui/src/setup/SetupContext.tsx
+++ b/apps/guardian-ui/src/setup/SetupContext.tsx
@@ -37,7 +37,6 @@ function makeInitialState(loadFromStorage = true): SetupState {
   }
 
   return {
-    isInitializing: true,
     role: null,
     progress: SetupProgress.Start,
     myName: '',
@@ -57,8 +56,6 @@ const reducer = (state: SetupState, action: SetupAction): SetupState => {
   switch (action.type) {
     case SETUP_ACTION_TYPE.SET_INITIAL_STATE:
       return makeInitialState(false);
-    case SETUP_ACTION_TYPE.SET_IS_INITIALIZING:
-      return { ...state, isInitializing: action.payload };
     case SETUP_ACTION_TYPE.SET_ROLE:
       return { ...state, role: action.payload };
     case SETUP_ACTION_TYPE.SET_PROGRESS:
@@ -186,12 +183,6 @@ export const SetupContextProvider: React.FC<SetupContextProviderProps> = ({
           // TODO: Present error to user
           console.error(err);
         }
-      })
-      .finally(() => {
-        dispatch({
-          type: SETUP_ACTION_TYPE.SET_IS_INITIALIZING,
-          payload: false,
-        });
       });
   }, [api]);
 

--- a/apps/guardian-ui/src/setup/types.tsx
+++ b/apps/guardian-ui/src/setup/types.tsx
@@ -87,7 +87,6 @@ export interface ConsensusState {
 }
 
 export interface SetupState {
-  isInitializing: boolean;
   role: GuardianRole | null;
   progress: SetupProgress;
   myName: string;
@@ -100,7 +99,6 @@ export interface SetupState {
 }
 
 export enum SETUP_ACTION_TYPE {
-  SET_IS_INITIALIZING = 'SET_IS_INITIALIZING',
   SET_INITIAL_STATE = 'SET_INITIAL_STATE',
   SET_ROLE = 'SET_ROLE',
   SET_PROGRESS = 'SET_PROGRESS',
@@ -118,10 +116,6 @@ export type SetupAction =
   | {
       type: SETUP_ACTION_TYPE.SET_INITIAL_STATE;
       payload: null;
-    }
-  | {
-      type: SETUP_ACTION_TYPE.SET_IS_INITIALIZING;
-      payload: boolean;
     }
   | {
       type: SETUP_ACTION_TYPE.SET_ROLE;


### PR DESCRIPTION
Simplifies application state management in Setup and admin UIs with the results that:
- Setup UI has a perceived faster load since we establish socket connections earlier when booting the app.
  - On boot, we always check latest server state to determine experience flow into Setup vs Admin UI
- Guardians can smoothly navigate back and forth, and reload the pages at every single step of setup UI
- On transition to Admin experience, we clear all setup-state persisted in local storage

fixes #34 