### PR TITLE
fix: include default client bitcoin rpc config in params

### DIFF
--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -90,10 +90,9 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
         );
         setNetwork(walletModule.consensus?.network.toString() || network);
         setBitcoinRpc(walletModule.local?.bitcoin_rpc || bitcoinRpc);
-        setClientDefaultBitcoinRpc(
-          walletModule.consensus?.client_default_bitcoin_rpc ||
-            clientDefaultBitcoinRpc
-        );
+        if (walletModule.consensus?.client_default_bitcoin_rpc) {
+          setClientDefaultBitcoinRpc(walletModule.consensus.client_default_bitcoin_rpc);
+        }
       }
     };
 

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -64,6 +64,11 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
     kind: '',
     url: '',
   });
+  const [clientDefaultBitcoinRpc, setClientDefaultBitcoinRpc] =
+    useState<BitcoinRpc>({
+      kind: '',
+      url: '',
+    });
   const [mintAmounts, setMintAmounts] = useState<number[]>([]);
   const [error, setError] = useState<string>();
 
@@ -85,6 +90,10 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
         );
         setNetwork(walletModule.consensus?.network.toString() || network);
         setBitcoinRpc(walletModule.local?.bitcoin_rpc || bitcoinRpc);
+        setClientDefaultBitcoinRpc(
+          walletModule.consensus?.client_default_bitcoin_rpc ||
+            clientDefaultBitcoinRpc
+        );
       }
     };
 
@@ -145,6 +154,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
                   consensus: {
                     finality_delay: parseInt(blockConfirmations, 10),
                     network: network as Network,
+                    client_default_bitcoin_rpc: clientDefaultBitcoinRpc,
                   },
                   local: {
                     bitcoin_rpc: bitcoinRpc,

--- a/apps/guardian-ui/src/setup/types.tsx
+++ b/apps/guardian-ui/src/setup/types.tsx
@@ -59,7 +59,11 @@ export type MintModuleParams = [
 export type WalletModuleParams = [
   ModuleKind.Wallet,
   {
-    consensus?: { finality_delay: number; network: Network };
+    consensus?: {
+      finality_delay: number;
+      network: Network;
+      client_default_bitcoin_rpc: BitcoinRpc;
+    };
     local?: {
       bitcoin_rpc: BitcoinRpc;
     };

--- a/flake.lock
+++ b/flake.lock
@@ -102,17 +102,17 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1689944162,
-        "narHash": "sha256-eXLoB0G+r0/vNElgBPY85fulLAQlTMcSsUVbPc/PLXg=",
+        "lastModified": 1689954312,
+        "narHash": "sha256-aRUvAaEZlLL+tfcn9n+wlAnEB6hx9vJ/FyaeGvvFKTE=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "39a6763c6ad755bf8cbc38cf010da71d193f9696",
+        "rev": "e2773cceae6b30a3f06406110a65f24ce2d99e32",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "39a6763c6ad755bf8cbc38cf010da71d193f9696",
+        "rev": "e2773cceae6b30a3f06406110a65f24ce2d99e32",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      url = "github:fedimint/fedimint?rev=39a6763c6ad755bf8cbc38cf010da71d193f9696";
+      url = "github:fedimint/fedimint?rev=e2773cceae6b30a3f06406110a65f24ce2d99e32";
     };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:


### PR DESCRIPTION
This block of code handling the config gen params is very error-prone. Related to https://github.com/fedimint/ui/issues/12.