### PR TITLE
Guardian UI app-wide auth

### DIFF
--- a/apps/guardian-ui/src/AppContext.tsx
+++ b/apps/guardian-ui/src/AppContext.tsx
@@ -59,12 +59,6 @@ export const AppContextProvider: React.FC<AppContextProviderProps> = ({
   const api = new GuardianApi();
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  // Attach the API to the window for debugging purposes.
-  useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).fedimintApi = api;
-  }, [api]);
-
   useEffect(() => {
     const load = async () => {
       try {

--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -28,6 +28,7 @@ interface RpcInterface {
 }
 
 enum SharedRpc {
+  auth = 'auth',
   status = 'status',
 }
 
@@ -111,7 +112,7 @@ class BaseGuardianApi
 
     // Attempt a 'status' rpc call with the temporary password.
     try {
-      await this.status();
+      await this.auth();
       return true;
     } catch (err) {
       // TODO: make sure error is auth error, not unrelated
@@ -121,6 +122,10 @@ class BaseGuardianApi
   };
 
   /*** Shared RPC methods */
+  auth = (): Promise<void> => {
+    return this.call(SharedRpc.auth);
+  };
+
   status = (): Promise<StatusResponse> => {
     return this.call(SharedRpc.status);
   };

--- a/apps/guardian-ui/src/components/Login.tsx
+++ b/apps/guardian-ui/src/components/Login.tsx
@@ -43,10 +43,10 @@ export const Login: React.FC = () => {
       <VStack pt={8} gap={2} align='start' justify='start'>
         <VStack align='start' gap={2}>
           <Heading size='md' fontWeight='medium'>
-            {t('setup.auth.title')}
+            {t('login.title')}
           </Heading>
           <Text size='md' fontWeight='medium'>
-            {t('setup.auth.subtitle')}
+            {t('login.subtitle')}
           </Text>
         </VStack>
         <FormControl isInvalid={!!error}>

--- a/apps/guardian-ui/src/components/Login.tsx
+++ b/apps/guardian-ui/src/components/Login.tsx
@@ -6,15 +6,17 @@ import {
   Button,
   VStack,
   FormErrorMessage,
+  Heading,
+  Text,
 } from '@chakra-ui/react';
-import { useSetupContext } from '../hooks';
-import { SETUP_ACTION_TYPE } from '../setup/types';
-import { formatApiErrorMessage } from '../utils/api';
 import { useTranslation } from '@fedimint/utils';
+import { useAppContext } from '../hooks';
+import { formatApiErrorMessage } from '../utils/api';
+import { APP_ACTION_TYPE } from '../types';
 
 export const Login: React.FC = () => {
   const { t } = useTranslation();
-  const { api, dispatch } = useSetupContext();
+  const { api, dispatch } = useAppContext();
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string>();
 
@@ -24,7 +26,7 @@ export const Login: React.FC = () => {
       try {
         const isValid = await api.testPassword(password);
         if (isValid) {
-          dispatch({ type: SETUP_ACTION_TYPE.SET_PASSWORD, payload: password });
+          dispatch({ type: APP_ACTION_TYPE.SET_NEEDS_AUTH, payload: false });
         } else {
           setError('Invalid password');
         }
@@ -38,7 +40,15 @@ export const Login: React.FC = () => {
 
   return (
     <form onSubmit={handleSubmit}>
-      <VStack gap={2} align='start' justify='start'>
+      <VStack pt={8} gap={2} align='start' justify='start'>
+        <VStack align='start' gap={2}>
+          <Heading size='md' fontWeight='medium'>
+            {t('setup.auth.title')}
+          </Heading>
+          <Text size='md' fontWeight='medium'>
+            {t('setup.auth.subtitle')}
+          </Text>
+        </VStack>
         <FormControl isInvalid={!!error}>
           <FormLabel>{t('login.password')}</FormLabel>
           <Input

--- a/apps/guardian-ui/src/components/SetupComplete.tsx
+++ b/apps/guardian-ui/src/components/SetupComplete.tsx
@@ -3,14 +3,14 @@ import { Flex, Heading, Text, Button, Icon } from '@chakra-ui/react';
 import { ReactComponent as ArrowRightIcon } from '../assets/svgs/arrow-right.svg';
 import { useAppContext } from '../hooks';
 import { useTranslation } from '@fedimint/utils';
+import { APP_ACTION_TYPE, Status } from '../types';
 
 export const SetupComplete: React.FC = () => {
   const { t } = useTranslation();
-  const { transitionToAdmin } = useAppContext();
+  const { dispatch } = useAppContext();
 
   const handleContinue = () => {
-    // TODO: Reset setup state
-    transitionToAdmin();
+    dispatch({ type: APP_ACTION_TYPE.SET_STATUS, payload: Status.Admin });
   };
 
   return (

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -26,6 +26,8 @@
     "peer": "Peer"
   },
   "login": {
+    "title": "Welcome back!",
+    "subtitle": "Please enter your password.",
     "password": "Password",
     "submit": "Submit"
   },
@@ -66,10 +68,6 @@
     "error-valid-number": "Please input a number of 1 or more."
   },
   "setup": {
-    "auth": {
-      "title": "Welcome back!",
-      "subtitle": "Please enter your password."
-    },
     "progress": {
       "start": {
         "title": "Welcome to Fedimint!",

--- a/apps/guardian-ui/src/languages/es.json
+++ b/apps/guardian-ui/src/languages/es.json
@@ -26,6 +26,8 @@
     "peer": "Par"
   },
   "login": {
+    "title": "¡Bienvenido de nuevo!",
+    "subtitle": "Por favor, ingresa tu contraseña.",
     "password": "Contraseña",
     "submit": "Enviar"
   },
@@ -66,10 +68,6 @@
     "error-valid-number": "Por favor, ingresa un número mayor o igual a 1."
   },
   "setup": {
-    "auth": {
-      "title": "¡Bienvenido de nuevo!",
-      "subtitle": "Por favor, ingresa tu contraseña."
-    },
     "progress": {
       "start": {
         "title": "¡Bienvenido a Fedimint!",

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -6,7 +6,6 @@ import { useSetupContext } from '../hooks';
 import { GuardianRole, SetupProgress, SETUP_ACTION_TYPE } from './types';
 import { RoleSelector } from '../components/RoleSelector';
 import { SetConfiguration } from '../components/SetConfiguration';
-import { Login } from '../components/Login';
 import { ConnectGuardians } from '../components/ConnectGuardians';
 import { RunDKG } from '../components/RunDKG';
 import { VerifyGuardians } from '../components/VerifyGuardians';
@@ -25,7 +24,7 @@ const PROGRESS_ORDER: SetupProgress[] = [
 export const FederationSetup: React.FC = () => {
   const { t } = useTranslation();
   const {
-    state: { progress, role, password, needsAuth },
+    state: { progress, role },
     dispatch,
   } = useSetupContext();
 
@@ -50,52 +49,47 @@ export const FederationSetup: React.FC = () => {
   let subtitle: React.ReactNode;
   let canGoBack = false;
   let content: React.ReactNode;
-  if (needsAuth && !password) {
-    title = t('setup.auth.title');
-    subtitle = t('setup.auth.subtitle');
-    content = <Login />;
-  } else {
-    switch (progress) {
-      case SetupProgress.Start:
-        title = t('setup.progress.start.title');
-        subtitle = t('setup.progress.start.subtitle');
-        content = <RoleSelector next={handleNext} />;
-        break;
-      case SetupProgress.SetConfiguration:
-        title = t('setup.progress.set-config.title');
-        subtitle = isHost
-          ? t('setup.progress.set-config.subtitle-leader')
-          : t('setup.progress.set-config.subtitle-follower');
-        content = <SetConfiguration next={handleNext} />;
-        canGoBack = true;
-        break;
-      case SetupProgress.ConnectGuardians:
-        title = isHost
-          ? t('setup.progress.connect-guardians.title-leader')
-          : t('setup.progress.connect-guardians.title-follower');
-        subtitle = isHost
-          ? t('setup.progress.connect-guardians.subtitle-leader')
-          : t('setup.progress.set-config.subtitle-follower');
-        content = <ConnectGuardians next={handleNext} />;
-        canGoBack = true;
-        break;
-      case SetupProgress.RunDKG:
-        title = t('setup.progress.run-dkg.title');
-        subtitle = t('setup.progress.run-dkg.subtitle');
-        content = <RunDKG next={handleNext} />;
-        break;
-      case SetupProgress.VerifyGuardians:
-        title = t('setup.progress.verify-guardians.title');
-        subtitle = t('setup.progress.verify-guardians.subtitle');
-        content = <VerifyGuardians next={handleNext} />;
-        break;
-      case SetupProgress.SetupComplete:
-        content = <SetupComplete />;
-        break;
-      default:
-        title = t('setup.progress.error.title');
-        subtitle = t('setup.progress.error.subtitle');
-    }
+
+  switch (progress) {
+    case SetupProgress.Start:
+      title = t('setup.progress.start.title');
+      subtitle = t('setup.progress.start.subtitle');
+      content = <RoleSelector next={handleNext} />;
+      break;
+    case SetupProgress.SetConfiguration:
+      title = t('setup.progress.set-config.title');
+      subtitle = isHost
+        ? t('setup.progress.set-config.subtitle-leader')
+        : t('setup.progress.set-config.subtitle-follower');
+      content = <SetConfiguration next={handleNext} />;
+      canGoBack = true;
+      break;
+    case SetupProgress.ConnectGuardians:
+      title = isHost
+        ? t('setup.progress.connect-guardians.title-leader')
+        : t('setup.progress.connect-guardians.title-follower');
+      subtitle = isHost
+        ? t('setup.progress.connect-guardians.subtitle-leader')
+        : t('setup.progress.set-config.subtitle-follower');
+      content = <ConnectGuardians next={handleNext} />;
+      canGoBack = true;
+      break;
+    case SetupProgress.RunDKG:
+      title = t('setup.progress.run-dkg.title');
+      subtitle = t('setup.progress.run-dkg.subtitle');
+      content = <RunDKG next={handleNext} />;
+      break;
+    case SetupProgress.VerifyGuardians:
+      title = t('setup.progress.verify-guardians.title');
+      subtitle = t('setup.progress.verify-guardians.subtitle');
+      content = <VerifyGuardians next={handleNext} />;
+      break;
+    case SetupProgress.SetupComplete:
+      content = <SetupComplete />;
+      break;
+    default:
+      title = t('setup.progress.error.title');
+      subtitle = t('setup.progress.error.subtitle');
   }
 
   return (

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -70,7 +70,7 @@ export const FederationSetup: React.FC = () => {
         : t('setup.progress.connect-guardians.title-follower');
       subtitle = isHost
         ? t('setup.progress.connect-guardians.subtitle-leader')
-        : t('setup.progress.set-config.subtitle-follower');
+        : t('setup.progress.connect-guardians.subtitle-follower');
       content = <ConnectGuardians next={handleNext} />;
       canGoBack = true;
       break;

--- a/apps/guardian-ui/src/setup/types.tsx
+++ b/apps/guardian-ui/src/setup/types.tsx
@@ -98,7 +98,6 @@ export interface SetupState {
   ourCurrentId: number | null;
   configGenParams: ConfigGenParams | null;
   numPeers: number;
-  needsAuth: boolean;
   peers: Peer[];
 }
 
@@ -108,7 +107,6 @@ export enum SETUP_ACTION_TYPE {
   SET_PROGRESS = 'SET_PROGRESS',
   SET_MY_NAME = 'SET_MY_NAME',
   SET_PASSWORD = 'SET_PASSWORD',
-  SET_NEEDS_AUTH = 'SET_NEEDS_AUTH',
   SET_CONFIG_GEN_PARAMS = 'SET_CONFIG_GEN_PARAMS',
   SET_NUM_PEERS = 'SET_NUM_PEERS',
   SET_PEERS = 'SET_PEERS',
@@ -140,10 +138,6 @@ export type SetupAction =
   | {
       type: SETUP_ACTION_TYPE.SET_PASSWORD;
       payload: string;
-    }
-  | {
-      type: SETUP_ACTION_TYPE.SET_NEEDS_AUTH;
-      payload: boolean;
     }
   | {
       type: SETUP_ACTION_TYPE.SET_NUM_PEERS;

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -111,3 +111,46 @@ interface RouteHint {
   short_channel_id: string;
   src_node_id: string;
 }
+
+export enum Status {
+  Loading,
+  Setup,
+  Admin,
+}
+
+export interface AppState {
+  status: Status;
+  needsAuth: boolean;
+  initServerStatus?: ServerStatus;
+  appError?: string;
+}
+
+export enum APP_ACTION_TYPE {
+  SET_STATUS = 'SET_STATUS',
+  SET_NEEDS_AUTH = 'SET_NEEDS_AUTH',
+  SET_INIT_SERVER_STATUS = 'SET_INIT_SERVER_STATUS',
+  SET_ERROR = 'SET_ERROR',
+}
+
+export type AppAction =
+  | {
+      type: APP_ACTION_TYPE.SET_STATUS;
+      payload: Status;
+    }
+  | {
+      type: APP_ACTION_TYPE.SET_NEEDS_AUTH;
+      payload: boolean;
+    }
+  | {
+      type: APP_ACTION_TYPE.SET_INIT_SERVER_STATUS;
+      payload: ServerStatus | undefined;
+    }
+  | {
+      type: APP_ACTION_TYPE.SET_ERROR;
+      payload: string | undefined;
+    };
+
+export interface InitializationState {
+  needsAuth: boolean;
+  serverStatus: ServerStatus;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -102,17 +102,17 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1689954312,
-        "narHash": "sha256-aRUvAaEZlLL+tfcn9n+wlAnEB6hx9vJ/FyaeGvvFKTE=",
+        "lastModified": 1690192390,
+        "narHash": "sha256-6dW9cAJ/7/QLYgKraFC6aD6ePlpcWQtOV3E/ToDMG7A=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "e2773cceae6b30a3f06406110a65f24ce2d99e32",
+        "rev": "9aef5c69e303d52639ffda4b32366c9b10fe6d92",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "e2773cceae6b30a3f06406110a65f24ce2d99e32",
+        "rev": "9aef5c69e303d52639ffda4b32366c9b10fe6d92",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      url = "github:fedimint/fedimint?rev=e2773cceae6b30a3f06406110a65f24ce2d99e32";
+      url = "github:fedimint/fedimint?rev=9aef5c69e303d52639ffda4b32366c9b10fe6d92";
     };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:


### PR DESCRIPTION
Secure app experiences by validating auth against FM servers
 - https://github.com/fedimint/fedimint/pull/2820
 - https://github.com/fedimint/fedimint/pull/2823
 
 This change applies auth as a top-level experience at the app level. A user must first pass the auth challenge (where necessary) To get to setup or admin experiences.