### PR TITLE
Don't throw away 3rd party modules

### DIFF
--- a/apps/guardian-ui/src/setup/types.tsx
+++ b/apps/guardian-ui/src/setup/types.tsx
@@ -69,7 +69,10 @@ export type WalletModuleParams = [
     };
   }
 ];
-export type OtherModuleParams = [string, object];
+export type OtherModuleParams = [
+  string,
+  { consensus?: object; local?: object }
+];
 export type AnyModuleParams =
   | LnModuleParams
   | MintModuleParams

--- a/apps/guardian-ui/src/utils/api.ts
+++ b/apps/guardian-ui/src/utils/api.ts
@@ -1,5 +1,6 @@
 import { JsonRpcError } from 'jsonrpc-client-websocket';
 import { AnyModuleParams, ConfigGenParams } from '../setup/types';
+import { ModuleKind } from '../types';
 
 /**
  * Given a config and the name of the module, return the module
@@ -13,6 +14,26 @@ export function getModuleParamsFromConfig<T extends AnyModuleParams[0]>(
   if (!config) return null;
   const module = Object.values(config.modules).find((m) => m[0] === moduleName);
   return module ? module[1] : null;
+}
+
+/**
+ * Given a config, filter out all non-default modules
+ */
+export function getOtherModuleParamsFromConfig(
+  config: ConfigGenParams | null
+): object {
+  if (!config) return {};
+
+  return Object.keys(config.modules)
+    .filter(
+      (key) =>
+        config.modules[parseInt(key)][0] != ModuleKind.Mint &&
+        config.modules[parseInt(key)][0] !== ModuleKind.Ln &&
+        config.modules[parseInt(key)][0] !== ModuleKind.Wallet
+    )
+    .reduce((cur, key) => {
+      return Object.assign(cur, { [key]: config.modules[parseInt(key)] });
+    }, {});
 }
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   fedimintd_1:
-    image: fedimint/fedimintd:9aef5c69e303d52639ffda4b32366c9b10fe6d92
+    image: fedimint/fedimintd:b2731b0d3068bb7eb8c8e721cf4abe504b07b569
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18173
@@ -19,7 +19,7 @@ services:
       - bitcoind
 
   gatewayd_1:
-    image: fedimint/gatewayd:9aef5c69e303d52639ffda4b32366c9b10fe6d92
+    image: fedimint/gatewayd:b2731b0d3068bb7eb8c8e721cf4abe504b07b569
     command: gatewayd lnd
     environment:
       # Path to folder containing gateway config and data files

--- a/flake.lock
+++ b/flake.lock
@@ -102,17 +102,17 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1690192390,
-        "narHash": "sha256-6dW9cAJ/7/QLYgKraFC6aD6ePlpcWQtOV3E/ToDMG7A=",
+        "lastModified": 1690833807,
+        "narHash": "sha256-rRFOf51hxjlfa4JbQt5tDgPo7jgg9Bgr7TVKLJU8i2g=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "9aef5c69e303d52639ffda4b32366c9b10fe6d92",
+        "rev": "b2731b0d3068bb7eb8c8e721cf4abe504b07b569",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "9aef5c69e303d52639ffda4b32366c9b10fe6d92",
+        "rev": "b2731b0d3068bb7eb8c8e721cf4abe504b07b569",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      url = "github:fedimint/fedimint?rev=9aef5c69e303d52639ffda4b32366c9b10fe6d92";
+      url = "github:fedimint/fedimint?rev=b2731b0d3068bb7eb8c8e721cf4abe504b07b569";
     };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:


### PR DESCRIPTION
This allows the UI to run 3rd party modules. It doesn't expose their parameters in the UI so you can only run with default parameters. But it's a good step forward. I was able to test it with a 3rd party module and it worked.

@wbobeirne could use a little help with typing things.

Updated docker and nix fedimint hashes to include [this commit](https://github.com/fedimint/fedimint/pull/2848) which enables devimint to do DKG with 3rd party modules.