### PR TITLE
fix: no verifyGuardians page for solo + JUSTFILE

### DIFF
--- a/JUSTFILE
+++ b/JUSTFILE
@@ -1,0 +1,4 @@
+mprocs:
+    mprocs -c mprocs.yml
+restart:
+    docker compose down && echo 'Removing fm dirs' && sudo rm -rf fm_* && echo 'Done' && mprocs -c mprocs.yml

--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -86,6 +86,11 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
   }, [api]);
 
   useEffect(() => {
+    // If we're the only guardian, skip this verify other guardians step.
+    if (numPeers === 1) {
+      next();
+      return;
+    }
     const isAllValid =
       peersWithHash &&
       peersWithHash.every(({ hash }, idx) => hash === enteredHashes[idx]);


### PR DESCRIPTION
- adds a catch to skip showing verifyguardians if it's a 1/1 federation.
- adds a JUSTFILE for commands