### PR TITLE
fix: mainnet key should be `bitcoin`

### DIFF
--- a/apps/guardian-ui/src/setup/types.tsx
+++ b/apps/guardian-ui/src/setup/types.tsx
@@ -22,7 +22,7 @@ export enum StepState {
 
 export enum Network {
   Testnet = 'testnet',
-  Mainnet = 'mainnet',
+  Mainnet = 'bitcoin',
   Regtest = 'regtest',
   Signet = 'signet',
 }


### PR DESCRIPTION
fixes #153 

should be `bitcoin` not `mainnet` because of these rust bitcoin types: https://docs.rs/bitcoin/latest/bitcoin/network/constants/enum.Network.html

I tested this by changing the HTML so that `<option value="bitcoin">` and submitted the form and it works

