### PR TITLE
Hook up `audit` rpc to UI balance

### DIFF
--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -1,6 +1,7 @@
 import { JsonRpcError, JsonRpcWebsocket } from 'jsonrpc-client-websocket';
 import { ConfigGenParams, ConsensusState, PeerHashMap } from './setup/types';
 import {
+  AuditSummary,
   ConfigResponse,
   FederationStatus,
   ServerStatus,
@@ -208,6 +209,7 @@ enum AdminRpc {
   inviteCode = 'invite_code',
   config = 'config',
   module = 'module',
+  audit = 'audit',
 }
 
 export enum LightningModuleRpc {
@@ -221,6 +223,7 @@ export interface AdminApiInterface extends SharedApiInterface {
   fetchEpochCount: () => Promise<number>;
   inviteCode: () => Promise<string>;
   config: (connection: string) => Promise<ConfigResponse>;
+  audit: () => Promise<AuditSummary>;
   moduleApiCall: <T>(moduleId: number, rpc: ModuleRpc) => Promise<T>;
 }
 
@@ -364,6 +367,10 @@ export class GuardianApi
 
   config = (connection: string): Promise<ConfigResponse> => {
     return this.base.call<ConfigResponse>(AdminRpc.config, connection);
+  };
+
+  audit = (): Promise<AuditSummary> => {
+    return this.base.call<AuditSummary>(AdminRpc.audit);
   };
 
   moduleApiCall = <T>(moduleId: number, rpc: ModuleRpc): Promise<T> => {

--- a/apps/guardian-ui/src/admin/FederationAdmin.tsx
+++ b/apps/guardian-ui/src/admin/FederationAdmin.tsx
@@ -3,7 +3,7 @@ import { Flex, Box, Icon, Text, useTheme, Heading } from '@chakra-ui/react';
 import { CopyInput } from '@fedimint/ui';
 import { useTranslation } from '@fedimint/utils';
 import { useAdminContext } from '../hooks';
-import { ConfigResponse, StatusResponse } from '../types';
+import { AuditSummary, ConfigResponse, StatusResponse } from '../types';
 import { GatewaysCard } from '../components/GatewaysCard';
 import { ReactComponent as CopyIcon } from '../assets/svgs/copy.svg';
 import { GuardiansCard } from '../components/GuardiansCard';
@@ -16,6 +16,7 @@ export const FederationAdmin: React.FC = () => {
   const { api } = useAdminContext();
   const [status, setStatus] = useState<StatusResponse>();
   const [inviteCode, setInviteCode] = useState<string>('');
+  const [auditSummary, setAuditSummary] = useState<AuditSummary>();
   const [config, setConfig] = useState<ConfigResponse>();
   const { t } = useTranslation();
 
@@ -23,6 +24,7 @@ export const FederationAdmin: React.FC = () => {
     // TODO: poll server status
     api.status().then(setStatus).catch(console.error);
     api.inviteCode().then(setInviteCode).catch(console.error);
+    api.audit().then(setAuditSummary).catch(console.error);
   }, [api]);
 
   useEffect(() => {

--- a/apps/guardian-ui/src/admin/FederationAdmin.tsx
+++ b/apps/guardian-ui/src/admin/FederationAdmin.tsx
@@ -3,7 +3,7 @@ import { Flex, Box, Icon, Text, useTheme, Heading } from '@chakra-ui/react';
 import { CopyInput } from '@fedimint/ui';
 import { useTranslation } from '@fedimint/utils';
 import { useAdminContext } from '../hooks';
-import { AuditSummary, ConfigResponse, StatusResponse } from '../types';
+import { ConfigResponse, StatusResponse } from '../types';
 import { GatewaysCard } from '../components/GatewaysCard';
 import { ReactComponent as CopyIcon } from '../assets/svgs/copy.svg';
 import { GuardiansCard } from '../components/GuardiansCard';
@@ -16,7 +16,6 @@ export const FederationAdmin: React.FC = () => {
   const { api } = useAdminContext();
   const [status, setStatus] = useState<StatusResponse>();
   const [inviteCode, setInviteCode] = useState<string>('');
-  const [auditSummary, setAuditSummary] = useState<AuditSummary>();
   const [config, setConfig] = useState<ConfigResponse>();
   const { t } = useTranslation();
 
@@ -24,7 +23,6 @@ export const FederationAdmin: React.FC = () => {
     // TODO: poll server status
     api.status().then(setStatus).catch(console.error);
     api.inviteCode().then(setInviteCode).catch(console.error);
-    api.audit().then(setAuditSummary).catch(console.error);
   }, [api]);
 
   useEffect(() => {

--- a/apps/guardian-ui/src/components/BalanceCard.tsx
+++ b/apps/guardian-ui/src/components/BalanceCard.tsx
@@ -1,21 +1,37 @@
-import { Card, CardBody, CardHeader, Text } from '@chakra-ui/react';
+import { Card, CardBody, CardHeader, Skeleton, Text } from '@chakra-ui/react';
 import { KeyValues } from '@fedimint/ui';
-import { useTranslation } from '@fedimint/utils';
-import React, { useMemo } from 'react';
+import { MSats, formatMsatsToBtc, useTranslation } from '@fedimint/utils';
+import React, { useEffect, useMemo, useState } from 'react';
+import { AuditSummary } from '../types';
+import { useAdminContext } from '../hooks';
 
 export const BalanceCard: React.FC = () => {
   const { t } = useTranslation();
+  const { api } = useAdminContext();
+  const [auditSummary, setAuditSummary] = useState<AuditSummary>();
+
+  const walletBalance = auditSummary
+    ? auditSummary.module_summaries.wallet?.net_assets || (0 as MSats)
+    : undefined;
+
+  useEffect(() => {
+    api.audit().then(setAuditSummary).catch(console.error);
+  }, [api]);
 
   const keyValues = useMemo(
     () => [
       {
         key: 'bitcoin',
         label: t('common.bitcoin'),
-        // TODO: Use `audit` api to fill this in
-        value: '0.00000000',
+        value:
+          typeof walletBalance === 'number' ? (
+            formatMsatsToBtc(walletBalance)
+          ) : (
+            <Skeleton height='20px' />
+          ),
       },
     ],
-    [t]
+    [walletBalance, t]
   );
 
   return (

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -1,3 +1,5 @@
+import type { MSats } from '@fedimint/utils';
+
 export enum ServerStatus {
   AwaitingPassword = 'AwaitingPassword',
   SharingConfigGenParams = 'SharingConfigGenParams',
@@ -155,11 +157,10 @@ export interface InitializationState {
 }
 
 export interface ModuleSummary {
-  net_assets: bigint;
+  net_assets: MSats;
 }
 
 export interface AuditSummary {
-  // 9,007,199,254,740,991 milli sats is the upper limit, or ~9007 bitcoin. Should be good?
-  net_assets: bigint;
-  module_summaries: Record<string, ModuleSummary>;
+  net_assets: MSats;
+  module_summaries: Record<string, ModuleSummary | undefined>;
 }

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -153,3 +153,13 @@ export interface InitializationState {
   needsAuth: boolean;
   serverStatus: ServerStatus;
 }
+
+export interface ModuleSummary {
+  net_assets: bigint;
+}
+
+export interface AuditSummary {
+  // 9,007,199,254,740,991 milli sats is the upper limit, or ~9007 bitcoin. Should be good?
+  net_assets: bigint;
+  module_summaries: Record<string, ModuleSummary>;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       - '18184:18184'
     volumes:
       - ./fm_2/data:/data
+    depends_on:
+      - bitcoind
 
   # gatewayd_2:
   #   image: fedimint/gatewayd:master
@@ -92,6 +94,8 @@ services:
       - '18185:18185'
     volumes:
       - ./fm_3/data:/data
+    depends_on:
+      - bitcoind
 
   fedimintd_4:
     image: fedimint/fedimintd:v0.1.0-rc3
@@ -107,6 +111,8 @@ services:
       - '18186:18186'
     volumes:
       - ./fm_4/data:/data
+    depends_on:
+      - bitcoind
 
   bitcoind:
     image: btcpayserver/bitcoin:24.1

--- a/packages/utils/src/format.tsx
+++ b/packages/utils/src/format.tsx
@@ -1,3 +1,5 @@
+import { MSats } from './types';
+
 /**
  * Given a string, turn it into an "ellipsis sandwich" with the start and
  * end showing. If the text is shorter than it would be with an ellipsis,
@@ -8,4 +10,15 @@ export function formatEllipsized(text: string, size = 6) {
     return text;
   }
   return `${text.substring(0, size)}...${text.substring(text.length - size)}`;
+}
+
+/**
+ * Given some number of msats, return a formatted string in the format of
+ * 0.0000000 or 1,234,5678.9000000
+ */
+export function formatMsatsToBtc(msats: MSats): string {
+  return Intl.NumberFormat(undefined, {
+    style: 'decimal',
+    minimumFractionDigits: 8,
+  }).format(msats / 1_00_000_000_000);
 }

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -1,2 +1,3 @@
 export * from './i18n';
 export * from './format';
+export * from './types';

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,0 +1,5 @@
+// Opaque numeric types to avoid mixing different denominations of bitcoin
+type BitcoinUnit<K, T> = K & { _: T };
+export type Btc = BitcoinUnit<number, 'Btc'>;
+export type Sats = BitcoinUnit<number, 'Sats'>;
+export type MSats = BitcoinUnit<number, 'MSats'>;


### PR DESCRIPTION
Built on #168, fixes part of #95

Shout out @EthnTuttle for getting started on this

### What This Does

* Adds the `api.audit` call for federation & module assets and liabilities
* Hooks up the `wallet` module's `net_assets` to the `<BalanceCard />`
* Adds new shared types to `packages/utils`
  * Opaque number types have been added for `Btc`, `Sats`, and `MSats` that makes it so that API types and functions can dictate which specific units they accept, to avoid the ambiguity of `number` not being clear what denomination it is
* Adds missing `docker-compose.yml` `depends_on: bitcoin` configs for fedimintds

## Screenshots

<img width="1196" alt="Screenshot 2023-08-31 at 4 31 14 PM" src="https://github.com/fedimint/ui/assets/649992/9b4022b4-721d-408b-8d5f-5e34e7c4a494">
