### PR TITLE
Bitcoin node config + types refactor

### DIFF
--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -9,6 +9,7 @@ import {
   ConfigGenParams,
   ConsensusState,
   PeerHashMap,
+  ModulesConfigResponse,
 } from './types';
 
 export interface SocketAndAuthInterface {
@@ -210,6 +211,7 @@ enum AdminRpc {
   federationStatus = 'consensus_status',
   inviteCode = 'invite_code',
   config = 'config',
+  modulesConfig = 'modules_config_json',
   module = 'module',
   audit = 'audit',
 }
@@ -226,6 +228,7 @@ export interface AdminApiInterface extends SharedApiInterface {
   inviteCode: () => Promise<string>;
   config: (connection: string) => Promise<ConfigResponse>;
   audit: () => Promise<AuditSummary>;
+  modulesConfig: () => Promise<ModulesConfigResponse>;
   moduleApiCall: <T>(moduleId: number, rpc: ModuleRpc) => Promise<T>;
 }
 
@@ -373,6 +376,10 @@ export class GuardianApi
 
   audit = (): Promise<AuditSummary> => {
     return this.base.call<AuditSummary>(AdminRpc.audit);
+  };
+
+  modulesConfig = () => {
+    return this.base.call<ModulesConfigResponse>(AdminRpc.modulesConfig);
   };
 
   moduleApiCall = <T>(moduleId: number, rpc: ModuleRpc): Promise<T> => {

--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -1,5 +1,4 @@
 import { JsonRpcError, JsonRpcWebsocket } from 'jsonrpc-client-websocket';
-import { ConfigGenParams, ConsensusState, PeerHashMap } from './setup/types';
 import {
   AuditSummary,
   ConfigResponse,
@@ -7,6 +6,9 @@ import {
   ServerStatus,
   StatusResponse,
   Versions,
+  ConfigGenParams,
+  ConsensusState,
+  PeerHashMap,
 } from './types';
 
 export interface SocketAndAuthInterface {

--- a/apps/guardian-ui/src/admin/FederationAdmin.tsx
+++ b/apps/guardian-ui/src/admin/FederationAdmin.tsx
@@ -3,7 +3,11 @@ import { Flex, Box, Icon, Text, useTheme, Heading } from '@chakra-ui/react';
 import { CopyInput } from '@fedimint/ui';
 import { useTranslation } from '@fedimint/utils';
 import { useAdminContext } from '../hooks';
-import { ConfigResponse, StatusResponse } from '../types';
+import {
+  ConfigResponse,
+  ModulesConfigResponse,
+  StatusResponse,
+} from '../types';
 import { GatewaysCard } from '../components/GatewaysCard';
 import { ReactComponent as CopyIcon } from '../assets/svgs/copy.svg';
 import { GuardiansCard } from '../components/GuardiansCard';
@@ -17,12 +21,14 @@ export const FederationAdmin: React.FC = () => {
   const [status, setStatus] = useState<StatusResponse>();
   const [inviteCode, setInviteCode] = useState<string>('');
   const [config, setConfig] = useState<ConfigResponse>();
+  const [modulesConfigs, setModulesConfigs] = useState<ModulesConfigResponse>();
   const { t } = useTranslation();
 
   useEffect(() => {
     // TODO: poll server status
     api.status().then(setStatus).catch(console.error);
     api.inviteCode().then(setInviteCode).catch(console.error);
+    api.modulesConfig().then(setModulesConfigs).catch(console.error);
   }, [api]);
 
   useEffect(() => {
@@ -69,7 +75,7 @@ export const FederationAdmin: React.FC = () => {
           <FederationInfoCard status={status} />
           <Flex w='100%' direction='column' gap={5}>
             <BalanceCard />
-            <BitcoinNodeCard config={config} />
+            <BitcoinNodeCard modulesConfigs={modulesConfigs} />
           </Flex>
         </Flex>
         <GuardiansCard status={status} config={config} />

--- a/apps/guardian-ui/src/components/BitcoinNodeCard.tsx
+++ b/apps/guardian-ui/src/components/BitcoinNodeCard.tsx
@@ -32,7 +32,7 @@ export const BitcoinNodeCard: React.FC<Props> = ({ modulesConfigs }) => {
         ),
       },
       {
-        key: 'blockHeight',
+        key: 'network',
         label: t('federation-dashboard.bitcoin-node.network-label'),
         value: walletConfig ? (
           walletConfig.network

--- a/apps/guardian-ui/src/components/BitcoinNodeCard.tsx
+++ b/apps/guardian-ui/src/components/BitcoinNodeCard.tsx
@@ -1,15 +1,22 @@
-import { Card, CardBody, CardHeader, Text } from '@chakra-ui/react';
+import { Card, CardBody, CardHeader, Skeleton, Text } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
 import React, { useMemo } from 'react';
-import { ConfigResponse } from '../types';
+import { ModuleConfig, ModuleKind, ModulesConfigResponse } from '../types';
 import { KeyValues } from '@fedimint/ui';
 
 interface Props {
-  config: ConfigResponse | undefined;
+  modulesConfigs: ModulesConfigResponse | undefined;
 }
 
-export const BitcoinNodeCard: React.FC<Props> = () => {
+export const BitcoinNodeCard: React.FC<Props> = ({ modulesConfigs }) => {
   const { t } = useTranslation();
+
+  const walletConfig = modulesConfigs
+    ? Object.values(modulesConfigs).find(
+        (config): config is ModuleConfig<ModuleKind.Wallet> =>
+          config.kind === ModuleKind.Wallet
+      )
+    : undefined;
 
   // TODO: Populate values from config.client_config.modules.config
   // It's currently mysteriously hex encoded
@@ -18,15 +25,23 @@ export const BitcoinNodeCard: React.FC<Props> = () => {
       {
         key: 'url',
         label: t('federation-dashboard.bitcoin-node.url-label'),
-        value: t('common.unknown'),
+        value: walletConfig ? (
+          walletConfig.client_default_bitcoin_rpc?.url
+        ) : (
+          <Skeleton height='24px' width='160px' />
+        ),
       },
       {
         key: 'blockHeight',
-        label: t('federation-dashboard.bitcoin-node.block-height-label'),
-        value: t('common.unknown'),
+        label: t('federation-dashboard.bitcoin-node.network-label'),
+        value: walletConfig ? (
+          walletConfig.network
+        ) : (
+          <Skeleton height='24px' width='100px' />
+        ),
       },
     ],
-    [t]
+    [walletConfig, t]
   );
 
   return (

--- a/apps/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/apps/guardian-ui/src/components/ConnectGuardians.tsx
@@ -18,7 +18,7 @@ import { CopyInput, Table, TableRow } from '@fedimint/ui';
 import { useTranslation } from '@fedimint/utils';
 import { useConsensusPolling, useSetupContext } from '../hooks';
 import { ModuleKind, ServerStatus } from '../types';
-import { GuardianRole } from '../setup/types';
+import { GuardianRole } from '../types';
 import { getModuleParamsFromConfig } from '../utils/api';
 import { ReactComponent as CopyIcon } from '../assets/svgs/copy.svg';
 

--- a/apps/guardian-ui/src/components/RoleSelector.tsx
+++ b/apps/guardian-ui/src/components/RoleSelector.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Button, VStack, Icon } from '@chakra-ui/react';
 import { RadioButtonGroup, RadioButtonOption } from '@fedimint/ui';
-import { GuardianRole, SETUP_ACTION_TYPE } from '../setup/types';
+import { GuardianRole, SETUP_ACTION_TYPE } from '../types';
 import { ReactComponent as ArrowRightIcon } from '../assets/svgs/arrow-right.svg';
 import { ReactComponent as CheckIcon } from '../assets/svgs/check.svg';
 import { ReactComponent as StarsIcon } from '../assets/svgs/stars.svg';

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -14,12 +14,7 @@ import {
 import { useTranslation } from '@fedimint/utils';
 import { FormGroup, FormGroupHeading } from '@fedimint/ui';
 import { useSetupContext } from '../hooks';
-import {
-  BitcoinRpc,
-  ConfigGenParams,
-  GuardianRole,
-  Network,
-} from '../setup/types';
+import { BitcoinRpc, ConfigGenParams, GuardianRole, Network } from '../types';
 import { ReactComponent as FedimintLogo } from '../assets/svgs/fedimint.svg';
 import { ReactComponent as BitcoinLogo } from '../assets/svgs/bitcoin.svg';
 import { ReactComponent as ArrowRightIcon } from '../assets/svgs/arrow-right.svg';

--- a/apps/guardian-ui/src/components/SetupProgress.tsx
+++ b/apps/guardian-ui/src/components/SetupProgress.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Center, Flex, Text, useTheme } from '@chakra-ui/react';
 import { ReactComponent as CheckIcon } from '../assets/svgs/white-check.svg';
-import { StepState } from '../setup/types';
+import { StepState } from '../types';
 
 interface StepProps {
   text: string;

--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -17,7 +17,7 @@ import {
 } from '@chakra-ui/react';
 import { CopyInput, FormGroup, Table } from '@fedimint/ui';
 import { useConsensusPolling, useSetupContext } from '../hooks';
-import { GuardianRole, Peer } from '../setup/types';
+import { GuardianRole, Peer } from '../types';
 import { ReactComponent as ArrowRightIcon } from '../assets/svgs/arrow-right.svg';
 import { ReactComponent as CopyIcon } from '../assets/svgs/copy.svg';
 import { formatApiErrorMessage } from '../utils/api';

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -32,7 +32,7 @@
     "bitcoin-node": {
       "label": "Bitcoin Node",
       "url-label": "URL",
-      "block-height-label": "Current block height"
+      "network-label": "Network"
     },
     "guardians": {
       "label": "Guardians",

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Text, Heading, Icon, VStack } from '@chakra-ui/react';
 import { ReactComponent as ArrowLeftIcon } from '../assets/svgs/arrow-left.svg';
 import { useTranslation } from '@fedimint/utils';
 import { useSetupContext } from '../hooks';
-import { GuardianRole, SetupProgress, SETUP_ACTION_TYPE } from './types';
+import { GuardianRole, SetupProgress, SETUP_ACTION_TYPE } from '../types';
 import { RoleSelector } from '../components/RoleSelector';
 import { SetConfiguration } from '../components/SetConfiguration';
 import { ConnectGuardians } from '../components/ConnectGuardians';

--- a/apps/guardian-ui/src/setup/SetupContext.tsx
+++ b/apps/guardian-ui/src/setup/SetupContext.tsx
@@ -13,8 +13,8 @@ import {
   SETUP_ACTION_TYPE,
   SetupProgress,
   ConfigGenParams,
-} from './types';
-import { ServerStatus } from '../types';
+  ServerStatus,
+} from '../types';
 import { GuardianApi } from '../GuardianApi';
 
 const LOCAL_STORAGE_SETUP_KEY = 'setup-guardian-ui-state';

--- a/apps/guardian-ui/src/types/api.ts
+++ b/apps/guardian-ui/src/types/api.ts
@@ -22,6 +22,14 @@ export interface PeerStatus {
   flagged: boolean;
 }
 
+export interface Peer {
+  name: string;
+  cert: string;
+  api_url: string;
+  p2p_url: string;
+  status: ServerStatus;
+}
+
 export interface FederationStatus {
   session_count: number;
   peers_online: number;
@@ -113,47 +121,16 @@ interface RouteHint {
   src_node_id: string;
 }
 
-export enum Status {
-  Loading,
-  Setup,
-  Admin,
+export enum Network {
+  Testnet = 'testnet',
+  Mainnet = 'bitcoin',
+  Regtest = 'regtest',
+  Signet = 'signet',
 }
 
-export interface AppState {
-  status: Status;
-  needsAuth: boolean;
-  initServerStatus?: ServerStatus;
-  appError?: string;
-}
-
-export enum APP_ACTION_TYPE {
-  SET_STATUS = 'SET_STATUS',
-  SET_NEEDS_AUTH = 'SET_NEEDS_AUTH',
-  SET_INIT_SERVER_STATUS = 'SET_INIT_SERVER_STATUS',
-  SET_ERROR = 'SET_ERROR',
-}
-
-export type AppAction =
-  | {
-      type: APP_ACTION_TYPE.SET_STATUS;
-      payload: Status;
-    }
-  | {
-      type: APP_ACTION_TYPE.SET_NEEDS_AUTH;
-      payload: boolean;
-    }
-  | {
-      type: APP_ACTION_TYPE.SET_INIT_SERVER_STATUS;
-      payload: ServerStatus | undefined;
-    }
-  | {
-      type: APP_ACTION_TYPE.SET_ERROR;
-      payload: string | undefined;
-    };
-
-export interface InitializationState {
-  needsAuth: boolean;
-  serverStatus: ServerStatus;
+export interface BitcoinRpc {
+  kind: string;
+  url: string;
 }
 
 export interface ModuleSummary {

--- a/apps/guardian-ui/src/types/api.ts
+++ b/apps/guardian-ui/src/types/api.ts
@@ -141,3 +141,41 @@ export interface AuditSummary {
   net_assets: MSats;
   module_summaries: Record<string, ModuleSummary | undefined>;
 }
+
+// Consider sharing these types with types/setup.ts *ModuleParams? Need to
+// confirm that setup API returns identical types to the admin API.
+interface ModuleConfigs {
+  [ModuleKind.Ln]: {
+    network: Network;
+    fee_consensus: {
+      contract_input: number;
+      contract_output: number;
+    };
+  };
+  [ModuleKind.Mint]: {
+    fee_consensus: {
+      note_issuance_abs: number;
+      note_spend_abs: number;
+    };
+    max_notes_per_denomination: number;
+    peer_tbs_pks: Record<number, Record<number, string>>;
+  };
+  [ModuleKind.Wallet]: {
+    client_default_bitcoin_rpc: BitcoinRpc;
+    default_fee: { sats_per_kvb: number };
+    fee_consensus: {
+      peg_in_abs: number;
+      peg_out_abs: number;
+    };
+    finality_delay: number;
+    network: Network;
+    peer_peg_in_keys: Record<number, { key: string }>;
+    peg_in_descriptor: number;
+  };
+}
+
+export type ModuleConfig<T extends ModuleKind = ModuleKind> = {
+  kind: T;
+} & ModuleConfigs[T];
+
+export type ModulesConfigResponse = Record<string, ModuleConfig>;

--- a/apps/guardian-ui/src/types/app.ts
+++ b/apps/guardian-ui/src/types/app.ts
@@ -1,0 +1,39 @@
+import { ServerStatus } from './api';
+
+export enum Status {
+  Loading,
+  Setup,
+  Admin,
+}
+
+export interface AppState {
+  status: Status;
+  needsAuth: boolean;
+  initServerStatus?: ServerStatus;
+  appError?: string;
+}
+
+export enum APP_ACTION_TYPE {
+  SET_STATUS = 'SET_STATUS',
+  SET_NEEDS_AUTH = 'SET_NEEDS_AUTH',
+  SET_INIT_SERVER_STATUS = 'SET_INIT_SERVER_STATUS',
+  SET_ERROR = 'SET_ERROR',
+}
+
+export type AppAction =
+  | {
+      type: APP_ACTION_TYPE.SET_STATUS;
+      payload: Status;
+    }
+  | {
+      type: APP_ACTION_TYPE.SET_NEEDS_AUTH;
+      payload: boolean;
+    }
+  | {
+      type: APP_ACTION_TYPE.SET_INIT_SERVER_STATUS;
+      payload: ServerStatus | undefined;
+    }
+  | {
+      type: APP_ACTION_TYPE.SET_ERROR;
+      payload: string | undefined;
+    };

--- a/apps/guardian-ui/src/types/index.ts
+++ b/apps/guardian-ui/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './app';
+export * from './api';
+export * from './setup';

--- a/apps/guardian-ui/src/types/setup.ts
+++ b/apps/guardian-ui/src/types/setup.ts
@@ -1,4 +1,4 @@
-import { MetaConfig, ModuleKind, ServerStatus } from '../types';
+import { MetaConfig, ModuleKind, Peer, BitcoinRpc, Network } from './api';
 
 export enum GuardianRole {
   Host = 'Host',
@@ -18,26 +18,6 @@ export enum StepState {
   Active = 'Active',
   InActive = 'InActive',
   Completed = 'Completed',
-}
-
-export enum Network {
-  Testnet = 'testnet',
-  Mainnet = 'bitcoin',
-  Regtest = 'regtest',
-  Signet = 'signet',
-}
-
-export interface Peer {
-  name: string;
-  cert: string;
-  api_url: string;
-  p2p_url: string;
-  status: ServerStatus;
-}
-
-export interface BitcoinRpc {
-  kind: string;
-  url: string;
 }
 
 export type PeerHashMap = Record<number, string>;

--- a/apps/guardian-ui/src/utils/api.ts
+++ b/apps/guardian-ui/src/utils/api.ts
@@ -1,5 +1,5 @@
 import { JsonRpcError } from 'jsonrpc-client-websocket';
-import { AnyModuleParams, ConfigGenParams } from '../setup/types';
+import { AnyModuleParams, ConfigGenParams } from '../types';
 import { ModuleKind } from '../types';
 
 /**


### PR DESCRIPTION
Built off of #168. Accomplishes the bitcoin node info part of #95.

Marking as draft until https://github.com/fedimint/fedimint/pull/3072 gets made into a new release candidate (v0.1.0-rc4).

### What This Does

* Hooks up the new `modules_config_json` rpc to an `api.modulesConfig()` method
* Hooks up `api.modulesConfig()` to the `<BitcoinNodeCard />` component
  * Replaced the "Block height" key / value with "Network" since we do not yet have a way to get block height
* Refactors all `guardian-ui` types to live in a single `types/` directory due to how frequently types are shared
  * Types can be separated into files, e.g. the old `types.ts` is split into `types/app.ts` and `types/api.ts`
  * Moved `setup/types.ts` into `types/setup.ts`, updated imports
  * There's likely more consolidation and cleanup that can be done in here, but this is a start

## Screenshots

<img width="1184" alt="Screenshot 2023-09-01 at 1 52 24 PM" src="https://github.com/fedimint/ui/assets/649992/117ea12f-bc0f-446b-af8d-9657cf5244d6">
