### PR TITLE
Fix password logic

### DIFF
--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -121,6 +121,10 @@ class BaseGuardianApi
     }
   };
 
+  clearPassword = () => {
+    sessionStorage.removeItem(SESSION_STORAGE_KEY);
+  };
+
   /*** Shared RPC methods */
   auth = (): Promise<void> => {
     return this.call(SharedRpc.auth);
@@ -128,10 +132,6 @@ class BaseGuardianApi
 
   status = (): Promise<StatusResponse> => {
     return this.call(SharedRpc.status);
-  };
-
-  clearPassword = () => {
-    sessionStorage.removeItem(SESSION_STORAGE_KEY);
   };
 
   call = async <T>(
@@ -247,6 +247,10 @@ export class GuardianApi
     return this.base.testPassword(password);
   };
 
+  clearPassword = () => {
+    return this.base.clearPassword();
+  };
+
   /*** Shared RPC methods */
 
   status = (): Promise<StatusResponse> => {
@@ -256,13 +260,16 @@ export class GuardianApi
   /*** Setup RPC methods ***/
 
   setPassword = async (password: string): Promise<void> => {
+    // Save password to session storage so that it's included in the r[c] call
     sessionStorage.setItem(SESSION_STORAGE_KEY, password);
 
-    return this.base.call(SetupRpc.setPassword);
-  };
-
-  private clearPassword = () => {
-    sessionStorage.removeItem(SESSION_STORAGE_KEY);
+    try {
+      await this.base.call(SetupRpc.setPassword);
+    } catch (err) {
+      // If the call failed, clear the password first then re-throw
+      this.clearPassword();
+      throw err;
+    }
   };
 
   setConfigGenConnections = async (

--- a/apps/guardian-ui/src/setup/SetupContext.tsx
+++ b/apps/guardian-ui/src/setup/SetupContext.tsx
@@ -130,8 +130,11 @@ export const SetupContextProvider: React.FC<SetupContextProviderProps> = ({
   initServerStatus,
   children,
 }: SetupContextProviderProps) => {
-  const [state, dispatch] = useReducer(reducer, initialState);
-  const { password, configGenParams, myName } = state;
+  const [state, dispatch] = useReducer(reducer, {
+    ...initialState,
+    password: api.getPassword() || initialState.password,
+  });
+  const { password, myName } = state;
   const [isPollingConsensus, setIsPollingConsensus] = useState(false);
 
   useEffect(() => {
@@ -237,9 +240,7 @@ export const SetupContextProvider: React.FC<SetupContextProviderProps> = ({
     useCallback(
       async ({ password: newPassword, myName, configs }) => {
         if (!password) {
-          if (!configGenParams) {
-            await api.setPassword(newPassword);
-          }
+          await api.setPassword(newPassword);
 
           dispatch({
             type: SETUP_ACTION_TYPE.SET_PASSWORD,
@@ -280,7 +281,7 @@ export const SetupContextProvider: React.FC<SetupContextProviderProps> = ({
           await fetchConsensusState();
         }
       },
-      [password, api, dispatch, configGenParams, fetchConsensusState]
+      [password, api, dispatch, fetchConsensusState]
     );
 
   const connectToHost = useCallback(


### PR DESCRIPTION
Closes #134

### What This Does

* Don't save password to `sessionStorage` if `save_password` RPC failed
* Run `testPassword` during initial load check instead of assuming it's valid, set `needsAuth` if it fails
* Initialize `SetupContext`'s `password` state with `api.getPassword()`
  * Since this is set, we can simplify the logic for not re-submitting password during `submitConfiguration()`

### Steps to Test

1. Get to the setup configuration form as a Leader
2. Fill out the form with an invalid Bitcoin RPC URI and submit, confirm you get an error
3. Scroll up to the password input, confirm it has become read-only
4. Refresh the page, confirm the password input is filled in and read-only
6. Edit your `sessionStorage` in the developer tools and set the password to an invalid password and refresh, confirm you are asked to login
    * On `master`, you will be taken to the setup page with the invalid password unchecked
8. Enter the password and submit, confirm you're taken back to setup and the password field is filled in and read-only
9. Fill out the form with valid inputs, confirm the form submits and continues successfully
    * On `master`, the form will fail to submit with an error that says you're expected to be in `AwaitingPassword`