### PR TITLE
fix(guardian-ui): run consensus in VerifyGuardians before continuing

### DIFF
--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -13,6 +13,7 @@ import {
   Tag,
   useTheme,
   HStack,
+  CircularProgress,
 } from '@chakra-ui/react';
 import { CopyInput, FormGroup, Table } from '@fedimint/ui';
 import { useConsensusPolling, useSetupContext } from '../hooks';
@@ -88,7 +89,12 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
   useEffect(() => {
     // If we're the only guardian, skip this verify other guardians step.
     if (numPeers === 1) {
-      next();
+      api
+        .startConsensus()
+        .then(next)
+        .catch((err) => {
+          setError(formatApiErrorMessage(err));
+        });
       return;
     }
     const isAllValid =
@@ -191,6 +197,17 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
     );
   } else if (!peersWithHash) {
     return <Spinner />;
+  } else if (numPeers === 1) {
+    return (
+      <VStack gap={8} justify='center' align='center'>
+        <CircularProgress
+          isIndeterminate
+          color={theme.colors.blue[400]}
+          size='200px'
+        />
+        <Heading size='sm'>{t('verify-guardians.starting-consensus')}</Heading>
+      </VStack>
+    );
   } else {
     return (
       <VStack gap={8} justify='start' align='start'>

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -143,7 +143,8 @@
     "table-column-status": "Status",
     "table-column-hash-input": "Paste verification code",
     "wait-all-guardians-verification": "Waiting for all Guardians to verify their codes",
-    "all-guardians-verified": "All Guardians have verified their codes"
+    "all-guardians-verified": "All Guardians have verified their codes",
+    "starting-consensus": "Starting consensus..."
   },
   "footer": {
     "docs-section-header": "Docs",


### PR DESCRIPTION
Closes #169.

### What This Does

* Runs `api.runConsensus` before continuing from the `VerifyGuardians` step if you're a solo federation
  * Renders a spinner instead of the verify configs table while this is happening
  * The header and description copy is still kinda wrong since there are no other guardians, but we can refine this later

## Screenshots


https://github.com/fedimint/ui/assets/649992/fc40b642-e285-4dc7-8004-9c1cad30e7af

