### PR TITLE
chore: upgrade fedimint nix dependency and docker containers to 0.1.0 release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   fedimintd_1:
-    image: fedimint/fedimintd:v0.1.0-rc3
+    image: fedimint/fedimintd:v0.1.0
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18173
@@ -19,7 +19,7 @@ services:
       - bitcoind
 
   gatewayd_1:
-    image: fedimint/gatewayd:v0.1.0-rc3
+    image: fedimint/gatewayd:v0.1.0
     command: gatewayd lnd
     environment:
       # Path to folder containing gateway config and data files
@@ -58,7 +58,7 @@ services:
       - fedimintd_1
 
   fedimintd_2:
-    image: fedimint/fedimintd:v0.1.0-rc3
+    image: fedimint/fedimintd:v0.1.0
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18173
@@ -81,7 +81,7 @@ services:
   #       ipv4_address: 10.5.0.8
 
   fedimintd_3:
-    image: fedimint/fedimintd:v0.1.0-rc3
+    image: fedimint/fedimintd:v0.1.0
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18174
@@ -98,7 +98,7 @@ services:
       - bitcoind
 
   fedimintd_4:
-    image: fedimint/fedimintd:v0.1.0-rc3
+    image: fedimint/fedimintd:v0.1.0
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18175

--- a/flake.lock
+++ b/flake.lock
@@ -102,16 +102,16 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1693340669,
-        "narHash": "sha256-UoURgNMHHVw+a7C3n3JtvK/2eSHsrZavSwqh1sG7n/U=",
+        "lastModified": 1694170424,
+        "narHash": "sha256-vsBmBOqcmkjSZu+K7h77crHpJEof6p2KVAIHVd0uLpY=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "eeeaeec19d5684be5684ff56e4cbc172e0af6259",
+        "rev": "6361d2ea0daf59f5114b698218065ea92353e387",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
-        "ref": "refs/tags/v0.1.0-rc3",
+        "ref": "refs/tags/v0.1.0",
         "repo": "fedimint",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      url = "github:fedimint/fedimint?ref=refs/tags/v0.1.0-rc3";
+      url = "github:fedimint/fedimint?ref=refs/tags/v0.1.0";
     };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:


### PR DESCRIPTION
I've been using this locally for a while and run through setup quite a few times, no breaking changes.

Unblocks #174 to be ready to review & merge.