### PR TITLE
fix(gateway-ui): use real federation name instead of hard-coded name

### DIFF
--- a/apps/gateway-ui/src/components/FederationCard.tsx
+++ b/apps/gateway-ui/src/components/FederationCard.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { Flex, Stack, useTheme, Heading } from '@chakra-ui/react';
 import { Federation } from '../types';
 import { InfoCard, DepositCard, BalanceCard, WithdrawCard } from '.';
+import { useTranslation } from '@fedimint/utils';
 
 interface FederationCardProps {
   federation: Federation;
 }
 
-export const FederationCard = (props: FederationCardProps): JSX.Element => {
-  const { federation_id, balance_msat } = props.federation;
+export const FederationCard: React.FC<FederationCardProps> = (props) => {
+  const { federation_id, balance_msat, config } = props.federation;
   const theme = useTheme();
+  const { t } = useTranslation();
 
   return (
     <>
@@ -21,7 +23,8 @@ export const FederationCard = (props: FederationCardProps): JSX.Element => {
           color={theme.colors.gray[900]}
           fontFamily={theme.fonts.heading}
         >
-          Human Action Coalition
+          {config.meta.federation_name ||
+            t('federation-card.default-federation-name')}
         </Heading>
         <Flex gap='24px' flexDir={{ base: 'column', sm: 'column', md: 'row' }}>
           <BalanceCard balance_msat={balance_msat} />

--- a/apps/gateway-ui/src/languages/en.json
+++ b/apps/gateway-ui/src/languages/en.json
@@ -34,7 +34,7 @@
     "mempool_deposit_link_text": "View on mempool.space"
   },
   "federation-card": {
-    "details": "Details"
+    "default-federation-name": "Your federation"
   },
   "header": {
     "connect": "Connect Federation",

--- a/apps/gateway-ui/src/types.tsx
+++ b/apps/gateway-ui/src/types.tsx
@@ -3,9 +3,38 @@ interface Fees {
   proportional_millionths: number;
 }
 
+export enum ModuleKind {
+  Ln = 'ln',
+  Mint = 'mint',
+  Wallet = 'wallet',
+}
+
+interface FedimintModule {
+  config: string;
+  kind: ModuleKind;
+  version: number;
+}
+
+interface ApiEndpoint {
+  name: string;
+  url: string;
+}
+
+export type MetaConfig = { federation_name?: string };
+
+export interface ClientConfig {
+  consensus_version: number;
+  epoch_pk: string;
+  federation_id: string;
+  api_endpoints: Record<number, ApiEndpoint>;
+  modules: Record<number, FedimintModule>;
+  meta: MetaConfig;
+}
+
 export interface Federation {
   federation_id: string;
   balance_msat: number;
+  config: ClientConfig;
 }
 
 export interface GatewayInfo {


### PR DESCRIPTION
Closes #167. Marked as draft until #193 is merged since that has the versions with the updated endpoint.

### What This Does

* Renders `federation.config.meta.federation_name` with fallback to default i18nified title
* Adds types for new `config` property on `Federation`
  * See #201 for future refactor