### PR TITLE
i18n SetupProgress + improve responsiveness

### DIFF
--- a/apps/guardian-ui/src/components/SetupProgress.tsx
+++ b/apps/guardian-ui/src/components/SetupProgress.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Center, Flex, Text, useTheme } from '@chakra-ui/react';
 import { ReactComponent as CheckIcon } from '../assets/svgs/white-check.svg';
 import { StepState } from '../setup/types';
+import { useTranslation } from '@fedimint/utils';
 
 interface StepProps {
   text: string;
@@ -85,7 +86,6 @@ const Step: React.FC<StepProps> = ({ text, state, isFirst }) => {
           state === StepState.Active ? '-18px' : '-12px'
         })`}
         textAlign='center'
-        textTransform='capitalize'
         fontWeight='600'
         fontSize={{ base: '12px', md: '14px' }}
         color={colorState(
@@ -110,16 +110,22 @@ export const SetupProgress: React.FC<SetupProgressProps> = ({
   setupProgress,
   isHost,
 }) => {
+  const { t } = useTranslation();
+
   return (
     <Flex justifyContent='center' alignItems='center' w='100%'>
       <Flex w='100%' px={{ base: 7, md: 9 }} justifyContent='space-between'>
         <Step
-          text='Federation details'
+          text={t('setup.progress.set-config.step')}
           state={setupProgress === 1 ? StepState.Active : StepState.Completed}
           isFirst
         />
         <Step
-          text={isHost ? 'Invite Guardians' : 'Confirm Info'}
+          text={t(
+            isHost
+              ? 'setup.progress.connect-guardians.step-leader'
+              : 'setup.progress.connect-guardians.step-follower'
+          )}
           state={
             setupProgress === 2
               ? StepState.Active
@@ -129,7 +135,7 @@ export const SetupProgress: React.FC<SetupProgressProps> = ({
           }
         />
         <Step
-          text='Verify Guardians'
+          text={t('setup.progress.verify-guardians.step')}
           state={
             setupProgress === 4
               ? StepState.Active
@@ -139,7 +145,7 @@ export const SetupProgress: React.FC<SetupProgressProps> = ({
           }
         />
         <Step
-          text='Done '
+          text={t('setup.progress.setup-complete.step')}
           state={setupProgress === 5 ? StepState.Completed : StepState.InActive}
         />
       </Flex>

--- a/apps/guardian-ui/src/components/SetupProgress.tsx
+++ b/apps/guardian-ui/src/components/SetupProgress.tsx
@@ -6,10 +6,10 @@ import { StepState } from '../setup/types';
 interface StepProps {
   text: string;
   state: StepState;
-  margin?: string;
+  isFirst?: boolean;
 }
 
-const Step: React.FC<StepProps> = ({ text, state, margin = '-48px' }) => {
+const Step: React.FC<StepProps> = ({ text, state, isFirst }) => {
   const theme = useTheme();
 
   const colorState = (
@@ -25,11 +25,12 @@ const Step: React.FC<StepProps> = ({ text, state, margin = '-48px' }) => {
 
   return (
     <Flex
-      w='100%'
+      w={isFirst ? 'auto' : '100%'}
+      position='relative'
       flexDir='column'
       alignItems='flex-end'
-      h='72px'
       justifyContent='space-between'
+      pb={{ base: '24px', md: '28px' }}
     >
       <Flex alignItems='center' h='100%' w='100%'>
         <Box
@@ -77,72 +78,24 @@ const Step: React.FC<StepProps> = ({ text, state, margin = '-48px' }) => {
         </Flex>
       </Flex>
       <Text
+        position='absolute'
+        bottom={0}
+        right={0}
+        transform={`translateX(50%) translateX(${
+          state === StepState.Active ? '-18px' : '-12px'
+        })`}
+        textAlign='center'
         textTransform='capitalize'
         fontWeight='600'
-        fontSize='14px'
+        fontSize={{ base: '12px', md: '14px' }}
         color={colorState(
           theme.colors.gray[700],
           theme.colors.blue[600],
-          theme.colors.blue[600]
+          theme.colors.gray[700]
         )}
         whiteSpace='nowrap'
-        mr={margin}
       >
         {text}
-      </Text>
-    </Flex>
-  );
-};
-
-const InitialStep: React.FC<Pick<StepProps, 'state'>> = ({ state }) => {
-  const theme = useTheme();
-
-  return (
-    <Flex
-      flexDir='column'
-      alignItems='flex-end'
-      h='72px'
-      justifyContent='space-between'
-    >
-      <Flex alignItems='center' h='100%'>
-        <Center
-          borderRadius='50%'
-          h={state === StepState.Active ? '36px' : '24px'}
-          w={state === StepState.Active ? '36px' : '24px'}
-          bgColor={theme.colors.blue[50]}
-        >
-          <Center
-            borderRadius='50%'
-            h='24px'
-            w='24px'
-            bgColor={theme.colors.blue[600]}
-          >
-            {state === StepState.Completed ? (
-              <CheckIcon />
-            ) : (
-              <Center
-                borderRadius='50%'
-                h='8px'
-                w='8px'
-                bgColor='white'
-              ></Center>
-            )}
-          </Center>
-        </Center>
-      </Flex>
-      <Text
-        textTransform='capitalize'
-        fontWeight='600'
-        fontSize='14px'
-        color={
-          state === StepState.InActive
-            ? theme.colors.gray[700]
-            : theme.colors.blue[600]
-        }
-        whiteSpace='nowrap'
-        mr='-42px'
-      >
-        Federation details
       </Text>
     </Flex>
   );
@@ -159,9 +112,11 @@ export const SetupProgress: React.FC<SetupProgressProps> = ({
 }) => {
   return (
     <Flex justifyContent='center' alignItems='center' w='100%'>
-      <Flex w='100%' justifyContent='space-between'>
-        <InitialStep
+      <Flex w='100%' px={{ base: 7, md: 9 }} justifyContent='space-between'>
+        <Step
+          text='Federation details'
           state={setupProgress === 1 ? StepState.Active : StepState.Completed}
+          isFirst
         />
         <Step
           text={isHost ? 'Invite Guardians' : 'Confirm Info'}
@@ -172,7 +127,6 @@ export const SetupProgress: React.FC<SetupProgressProps> = ({
               ? StepState.Completed
               : StepState.InActive
           }
-          margin={isHost ? '-48px' : '-32px'}
         />
         <Step
           text='Verify Guardians'
@@ -187,7 +141,6 @@ export const SetupProgress: React.FC<SetupProgressProps> = ({
         <Step
           text='Done '
           state={setupProgress === 5 ? StepState.Completed : StepState.InActive}
-          margin='-8px'
         />
       </Flex>
     </Flex>

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -97,18 +97,22 @@
     "progress": {
       "start": {
         "title": "Welcome to Fedimint!",
-        "subtitle": "Are you creating a Federation, or joining one?"
+        "subtitle": "Are you creating a Federation, or joining one?",
+        "step": "Federation details"
       },
       "set-config": {
         "title": "Let's set up your federation",
         "subtitle-leader": "Your Federation Followers will confirm this information on their end.",
-        "subtitle-follower": "Your Federation Leader will be setting up main Federation details. You’ll confirm them soon."
+        "subtitle-follower": "Your Federation Leader will be setting up main Federation details. You’ll confirm them soon.",
+        "step": "Federation details"
       },
       "connect-guardians": {
         "title-leader": "Invite your Guardians",
         "title-follower": "Confirm your Federation Information",
         "subtitle-leader": "Share the link with the other Guardians to get everyone on the same page. Once all the Guardians join, you’ll automatically move on to the next step.",
-        "subtitle-follower": "Make sure that the information here looks right, and that the Federation Guardians are correct. Click the Approve button when you’re sure it looks good."
+        "subtitle-follower": "Make sure that the information here looks right, and that the Federation Guardians are correct. Click the Approve button when you’re sure it looks good.",
+        "step-leader": "Invite Guardians",
+        "step-follower": "Confirm info"
       },
       "run-dkg": {
         "title": "Boom! Sharing info between Guardians",
@@ -116,7 +120,11 @@
       },
       "verify-guardians": {
         "title": "Verify your Guardians",
-        "subtitle": "Ask each Guardian for their verification code, and paste them below to check validity. We’re almost done!"
+        "subtitle": "Ask each Guardian for their verification code, and paste them below to check validity. We’re almost done!",
+        "step": "Verify guardians"
+      },
+      "setup-complete": {
+        "step": "Done!"
       },
       "error": {
         "title": "Unknown step",


### PR DESCRIPTION
Closes #179

### What This Does

* Wraps user-facing text in `SetupProgress` with `t()` translations
  * Updated to match Figma casing and punctuation
* Minor code cleanup & styling improvements for `SetupProgress`
  * Reduces copy-pasted code by removing `InitialStep` and just re-using `Step` with an `isFirst` prop
  * Replace hard coded negative margins with transform for text centering, to account for i18n dynamic text
  * Responsive styling to render better at smaller widths
  * Step text now renders gray for inactive past steps

## Screenshots

### Desktop width (before / after)

<img width="300" alt="Screenshot 2023-09-12 at 2 20 16 PM" src="https://github.com/fedimint/ui/assets/649992/17ebce71-4fc3-4985-bf30-91ea48806fac">
<img width="300" alt="Screenshot 2023-09-12 at 2 19 42 PM" src="https://github.com/fedimint/ui/assets/649992/435a11fd-97cb-4a82-8a7f-97e0b2d21556">


### Mobile width (before / after)

<img width="250" alt="Screenshot 2023-09-12 at 2 20 06 PM" src="https://github.com/fedimint/ui/assets/649992/f9ef70f2-d0ae-4af7-a912-99e6827aa22d">
<img width="250" alt="Screenshot 2023-09-12 at 2 19 53 PM" src="https://github.com/fedimint/ui/assets/649992/e6be8385-84bc-49ff-a3d6-5ee1d6962bf6">
