### PR TITLE
Update fedimint to version with AlephBFT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3'
 
 services:
   fedimintd_1:
-    image: fedimint/fedimintd:v0.1.0
+    # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
+    image: fedimint/fedimintd:a71267934a5ec2f0df28686fa21362386e762ca0
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18173
@@ -19,7 +20,8 @@ services:
       - bitcoind
 
   gatewayd_1:
-    image: fedimint/gatewayd:v0.1.0
+    # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
+    image: fedimint/gatewayd:a71267934a5ec2f0df28686fa21362386e762ca0
     command: gatewayd lnd
     environment:
       # Path to folder containing gateway config and data files
@@ -58,7 +60,8 @@ services:
       - fedimintd_1
 
   fedimintd_2:
-    image: fedimint/fedimintd:v0.1.0
+    # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
+    image: fedimint/fedimintd:a71267934a5ec2f0df28686fa21362386e762ca0
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18173
@@ -81,7 +84,8 @@ services:
   #       ipv4_address: 10.5.0.8
 
   fedimintd_3:
-    image: fedimint/fedimintd:v0.1.0
+    # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
+    image: fedimint/fedimintd:a71267934a5ec2f0df28686fa21362386e762ca0
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18174
@@ -98,7 +102,8 @@ services:
       - bitcoind
 
   fedimintd_4:
-    image: fedimint/fedimintd:v0.1.0
+    # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
+    image: fedimint/fedimintd:a71267934a5ec2f0df28686fa21362386e762ca0
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18175

--- a/flake.lock
+++ b/flake.lock
@@ -48,17 +48,17 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1691422976,
-        "narHash": "sha256-A8krh8yi73R8mSUk63EwM4liaqXk1dws44D4aueNOEw=",
-        "owner": "ipetkov",
+        "lastModified": 1695159108,
+        "narHash": "sha256-Uaav5HU0aDePH8uPHauUXIabJzeHxVu3em6SQXr40w8=",
+        "owner": "dpc",
         "repo": "crane",
-        "rev": "6c25eff4edca8556df21f55c63e49f20efe4be95",
+        "rev": "60dcbcab46446bb852473a995fb0008d74c8b78d",
         "type": "github"
       },
       "original": {
-        "owner": "ipetkov",
+        "owner": "dpc",
         "repo": "crane",
-        "rev": "6c25eff4edca8556df21f55c63e49f20efe4be95",
+        "rev": "60dcbcab46446bb852473a995fb0008d74c8b78d",
         "type": "github"
       }
     },
@@ -95,24 +95,23 @@
         "android-nixpkgs": "android-nixpkgs",
         "crane": "crane",
         "fenix": "fenix",
-        "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-kitman": "nixpkgs-kitman",
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1694170424,
-        "narHash": "sha256-vsBmBOqcmkjSZu+K7h77crHpJEof6p2KVAIHVd0uLpY=",
+        "lastModified": 1696461777,
+        "narHash": "sha256-foSoD1m8QqNL5OwvcJgwLz4zAX9NaJR4S7i4x6Qbkkw=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "6361d2ea0daf59f5114b698218065ea92353e387",
+        "rev": "a71267934a5ec2f0df28686fa21362386e762ca0",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
-        "ref": "refs/tags/v0.1.0",
         "repo": "fedimint",
+        "rev": "a71267934a5ec2f0df28686fa21362386e762ca0",
         "type": "github"
       }
     },
@@ -146,22 +145,6 @@
         "owner": "edolstra",
         "repo": "flake-compat",
         "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      url = "github:fedimint/fedimint?ref=refs/tags/v0.1.0";
+      # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
+      url = "github:fedimint/fedimint?rev=a71267934a5ec2f0df28686fa21362386e762ca0";
     };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:


### PR DESCRIPTION
This PR updates the nix and docker fedimint dependencies to the merge commit for [AlephBFT support ](https://github.com/fedimint/fedimint/pull/3313)

I successfully completed 3/4 local federation setups using both docker (`just mprocs`) and nix `(yarn nix-guardian`)