### PR TITLE
fix: add entries to dockerignore that are unnecessary or harmful to docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,13 @@
 
 # Nix build directory.
 /result
+
+# Host machine node modules
+**/node_modules
+
+# Host machine builds
+apps/*/build
+packages/*/dist
+
+# Fedimint data
+fm_*


### PR DESCRIPTION
Adds ignores for

* `node_modules`
* `apps` builds
* `packages` dists
* `fm_*` data dirs

Including these made images unnecessarily large, and could cause `docker build` to fail