### PR TITLE
feat: Add updation of dockerhub description from README in workflow [Fixes #210]

### DIFF
--- a/.github/workflows/gateway-ui.yml
+++ b/.github/workflows/gateway-ui.yml
@@ -48,6 +48,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Update the Docker Hub description
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         uses: peter-evans/dockerhub-description@v3
         with:
           username: fedimintui

--- a/.github/workflows/gateway-ui.yml
+++ b/.github/workflows/gateway-ui.yml
@@ -15,8 +15,10 @@ jobs:
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -29,12 +31,14 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
+
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v2
         with:
           username: fedimintui
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Build and push gateway-ui
         uses: docker/build-push-action@v4
         with:
@@ -42,3 +46,11 @@ jobs:
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Update the Docker Hub description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: fedimintui
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          repository: fedimintui/gateway-ui
+          readme-filepath: /apps/gateway-ui/README.md

--- a/.github/workflows/guardian-ui.yml
+++ b/.github/workflows/guardian-ui.yml
@@ -14,8 +14,10 @@ jobs:
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -28,12 +30,14 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
+
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v2
         with:
           username: fedimintui
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Build and push guardian-ui
         uses: docker/build-push-action@v4
         with:
@@ -41,3 +45,11 @@ jobs:
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Update the Docker Hub description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: fedimintui
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          repository: fedimintui/guardian-ui
+          readme-filepath: /apps/guardian-ui/README.md

--- a/.github/workflows/guardian-ui.yml
+++ b/.github/workflows/guardian-ui.yml
@@ -47,6 +47,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Update the Docker Hub description
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         uses: peter-evans/dockerhub-description@v3
         with:
           username: fedimintui


### PR DESCRIPTION
Fixes #210 

I have updated the `gateway-ui` and the `guardian-ui` images on DockerHub to update their descriptions from their respective READMEs. As there is no way to check GitHub actions locally, it is imperative that these workflow files are cross-verified before merging. 

Also, I'm thinking to add a `workflow-dispatch` option to these workflows. They would allow us to run these publishing to DockerHub actions as and when we want manually. Does this seem like functionality that we would like to have?