### PR TITLE
fix: Change the path for pushing to description to DockerHub

### DIFF
--- a/.github/workflows/gateway-ui.yml
+++ b/.github/workflows/gateway-ui.yml
@@ -54,4 +54,4 @@ jobs:
           username: fedimintui
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           repository: fedimintui/gateway-ui
-          readme-filepath: /apps/gateway-ui/README.md
+          readme-filepath: ./apps/gateway-ui/README.md

--- a/.github/workflows/guardian-ui.yml
+++ b/.github/workflows/guardian-ui.yml
@@ -53,4 +53,4 @@ jobs:
           username: fedimintui
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           repository: fedimintui/guardian-ui
-          readme-filepath: /apps/guardian-ui/README.md
+          readme-filepath: ./apps/guardian-ui/README.md


### PR DESCRIPTION
Recently #231 was merged to solve issue #210, but the merging of the same is causing the workflows to fail. I think the error is due to the way the relative path to the `README` files is supplied, and I have updated the same in this PR. Hopefully this would fix the failing workflow. 