### PR TITLE
Fix: Fix the DockerHub description push workflow [Fixes #235]

### DIFF
--- a/.github/workflows/gateway-ui.yml
+++ b/.github/workflows/gateway-ui.yml
@@ -47,6 +47,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Checkout repository content
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+        uses: actions/checkout@v4
+
+      # This workflow requires the repository content to be locally available to read the README
       - name: Update the Docker Hub description
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         uses: peter-evans/dockerhub-description@v3

--- a/.github/workflows/guardian-ui.yml
+++ b/.github/workflows/guardian-ui.yml
@@ -46,6 +46,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Checkout repository content
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+        uses: actions/checkout@v4
+
+      # This workflow requires the repository content to be locally available to read the README
       - name: Update the Docker Hub description
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         uses: peter-evans/dockerhub-description@v3


### PR DESCRIPTION
Fixes #235 

As mentioned in this [issue](https://github.com/peter-evans/dockerhub-description/issues/220) here, the `peter-evans/docker-description` requires the content of the repository to be checkout-ed to access the README content. I have added the same in this PR. 

This should hopefully fix the original issue #210!