### PR TITLE
refactor: Ban HStack and VStack components

### DIFF
--- a/apps/gateway-ui/src/App.tsx
+++ b/apps/gateway-ui/src/App.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Heading,
   Stack,
-  VStack,
   Text,
   Flex,
   useTheme,
@@ -93,10 +92,10 @@ export const App = React.memo(function Admin(): JSX.Element {
     <ApiProvider props={{ gateway }}>
       <Wrapper size='lg'>
         {error ? (
-          <VStack spacing={4}>
+          <Flex direction='column' gap={4}>
             <Heading size='md'>{t('common.error')}</Heading>
             <Text>{error}</Text>
-          </VStack>
+          </Flex>
         ) : (
           <Box>
             {gatewayInfo?.federations.length ? null : (

--- a/apps/gateway-ui/src/App.tsx
+++ b/apps/gateway-ui/src/App.tsx
@@ -92,7 +92,7 @@ export const App = React.memo(function Admin(): JSX.Element {
     <ApiProvider props={{ gateway }}>
       <Wrapper size='lg'>
         {error ? (
-          <Flex direction='column' gap={4}>
+          <Flex direction='column' gap={6}>
             <Heading size='md'>{t('common.error')}</Heading>
             <Text>{error}</Text>
           </Flex>

--- a/apps/gateway-ui/src/components/WithdrawCard.tsx
+++ b/apps/gateway-ui/src/components/WithdrawCard.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import {
   Box,
   Button,
+  Flex,
   Input,
   InputGroup,
   NumberInput,
@@ -15,7 +16,6 @@ import {
   ModalOverlay,
   Stack,
   Text,
-  VStack,
   useTheme,
 } from '@chakra-ui/react';
 import {
@@ -208,7 +208,11 @@ const ConfirmWithdrawModal = (
             <ModalHeader>{t('withdraw-card.confirm-withdraw')}</ModalHeader>
             <ModalCloseButton />
             <ModalBody>
-              <VStack alignItems='flex-start' justifyContent='space-between'>
+              <Flex
+                direction='column'
+                alignItems='flex-start'
+                justifyContent='space-between'
+              >
                 <Box>
                   <Text>{t('common.amount')}:</Text>
                   <Text>
@@ -220,7 +224,7 @@ const ConfirmWithdrawModal = (
                   <Text>{t('common.address')}:</Text>
                   <Text>{formatEllipsized(txRequest.address)}</Text>
                 </Box>
-              </VStack>
+              </Flex>
             </ModalBody>
             <ModalFooter>
               <Button

--- a/apps/gateway-ui/src/components/WithdrawCard.tsx
+++ b/apps/gateway-ui/src/components/WithdrawCard.tsx
@@ -212,6 +212,7 @@ const ConfirmWithdrawModal = (
                 direction='column'
                 alignItems='flex-start'
                 justifyContent='space-between'
+                gap={2}
               >
                 <Box>
                   <Text>{t('common.amount')}:</Text>

--- a/apps/guardian-ui/src/App.tsx
+++ b/apps/guardian-ui/src/App.tsx
@@ -19,7 +19,7 @@ export const App = React.memo(function App() {
   const content = useMemo(() => {
     if (state.appError) {
       return (
-        <Flex direction='column' gap={4}>
+        <Flex direction='column' gap={6}>
           <Heading size='md'>{t('common.error')}</Heading>
           <Text>{state.appError}</Text>
         </Flex>

--- a/apps/guardian-ui/src/App.tsx
+++ b/apps/guardian-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Box, VStack, Spinner, Heading, Text, Center } from '@chakra-ui/react';
+import { Box, Flex, Spinner, Heading, Text, Center } from '@chakra-ui/react';
 import { theme, Fonts, SharedChakraProvider, Wrapper } from '@fedimint/ui';
 import spaceGroteskTtf from '@fedimint/ui/assets/fonts/SpaceGrotesk-Variable.ttf';
 import interTtf from '@fedimint/ui/assets/fonts/Inter-Variable.ttf';
@@ -19,10 +19,10 @@ export const App = React.memo(function App() {
   const content = useMemo(() => {
     if (state.appError) {
       return (
-        <VStack spacing={4}>
+        <Flex direction='column' gap={4}>
           <Heading size='md'>{t('common.error')}</Heading>
           <Text>{state.appError}</Text>
-        </VStack>
+        </Flex>
       );
     }
 

--- a/apps/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/apps/guardian-ui/src/components/ConnectGuardians.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   FormControl,
   FormLabel,
-  VStack,
+  Flex,
   Button,
   FormHelperText,
   Spinner,
@@ -91,7 +91,14 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
     ];
 
     content = (
-      <VStack gap={3} justify='start' align='start' width='100%' maxWidth={400}>
+      <Flex
+        direction='column'
+        gap={3}
+        justify='start'
+        align='start'
+        width='100%'
+        maxWidth={400}
+      >
         <TableContainer width='100%'>
           <ChakraTable variant='simple'>
             <Tbody>
@@ -109,7 +116,7 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
             {t('connect-guardians.approve')}
           </Button>
         </div>
-      </VStack>
+      </Flex>
     );
   }
 
@@ -156,7 +163,7 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
   }, [numPeers, ourCurrentId, peers, t]);
 
   return (
-    <VStack width='100%' justify='start' align='start' gap={8}>
+    <Flex direction='column' width='100%' justify='start' align='start' gap={8}>
       {content}
       {peerTableRows.length && (
         <Table
@@ -166,6 +173,6 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
           rows={peerTableRows}
         />
       )}
-    </VStack>
+    </Flex>
   );
 };

--- a/apps/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/apps/guardian-ui/src/components/ConnectGuardians.tsx
@@ -93,7 +93,7 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
     content = (
       <Flex
         direction='column'
-        gap={3}
+        gap={5}
         justify='start'
         align='start'
         width='100%'
@@ -163,7 +163,13 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
   }, [numPeers, ourCurrentId, peers, t]);
 
   return (
-    <Flex direction='column' width='100%' justify='start' align='start' gap={8}>
+    <Flex
+      direction='column'
+      width='100%'
+      justify='start'
+      align='start'
+      gap={10}
+    >
       {content}
       {peerTableRows.length && (
         <Table

--- a/apps/guardian-ui/src/components/Login.tsx
+++ b/apps/guardian-ui/src/components/Login.tsx
@@ -40,8 +40,8 @@ export const Login: React.FC = () => {
 
   return (
     <form onSubmit={handleSubmit}>
-      <Flex direction='column' pt={8} gap={2} align='start' justify='start'>
-        <Flex direction='column' align='start' gap={2}>
+      <Flex direction='column' pt={8} gap={4} align='start' justify='start'>
+        <Flex direction='column' align='start' gap={4}>
           <Heading size='md' fontWeight='medium'>
             {t('login.title')}
           </Heading>

--- a/apps/guardian-ui/src/components/Login.tsx
+++ b/apps/guardian-ui/src/components/Login.tsx
@@ -4,7 +4,7 @@ import {
   FormControl,
   FormLabel,
   Button,
-  VStack,
+  Flex,
   FormErrorMessage,
   Heading,
   Text,
@@ -40,15 +40,15 @@ export const Login: React.FC = () => {
 
   return (
     <form onSubmit={handleSubmit}>
-      <VStack pt={8} gap={2} align='start' justify='start'>
-        <VStack align='start' gap={2}>
+      <Flex direction='column' pt={8} gap={2} align='start' justify='start'>
+        <Flex direction='column' align='start' gap={2}>
           <Heading size='md' fontWeight='medium'>
             {t('login.title')}
           </Heading>
           <Text size='md' fontWeight='medium'>
             {t('login.subtitle')}
           </Text>
-        </VStack>
+        </Flex>
         <FormControl isInvalid={!!error}>
           <FormLabel>{t('login.password')}</FormLabel>
           <Input
@@ -59,7 +59,7 @@ export const Login: React.FC = () => {
           {error && <FormErrorMessage>{error}</FormErrorMessage>}
         </FormControl>
         <Button type='submit'>{t('login.submit')}</Button>
-      </VStack>
+      </Flex>
     </form>
   );
 };

--- a/apps/guardian-ui/src/components/RunDKG.tsx
+++ b/apps/guardian-ui/src/components/RunDKG.tsx
@@ -80,7 +80,7 @@ export const RunDKG: React.FC<Props> = ({ next }) => {
   }, [peers]);
 
   return (
-    <Flex direction='column' gap={8} justify='center' align='center'>
+    <Flex direction='column' gap={10} justify='center' align='center'>
       <CircularProgress
         isIndeterminate={!isWaitingForOthers}
         value={isWaitingForOthers ? progress : undefined}

--- a/apps/guardian-ui/src/components/RunDKG.tsx
+++ b/apps/guardian-ui/src/components/RunDKG.tsx
@@ -3,7 +3,7 @@ import {
   CircularProgressLabel,
   Heading,
   Text,
-  VStack,
+  Flex,
   useTheme,
 } from '@chakra-ui/react';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -56,7 +56,7 @@ export const RunDKG: React.FC<Props> = ({ next }) => {
             setError(`${t('run-dkg.error-config')}`);
             break;
           default:
-            setError(`${t('run-dkg.error-default')} '${(status.server)}'`);
+            setError(`${t('run-dkg.error-default')} '${status.server}'`);
         }
       } catch (err) {
         setError(formatApiErrorMessage(err));
@@ -80,7 +80,7 @@ export const RunDKG: React.FC<Props> = ({ next }) => {
   }, [peers]);
 
   return (
-    <VStack gap={8} justify='center' align='center'>
+    <Flex direction='column' gap={8} justify='center' align='center'>
       <CircularProgress
         isIndeterminate={!isWaitingForOthers}
         value={isWaitingForOthers ? progress : undefined}
@@ -107,6 +107,6 @@ export const RunDKG: React.FC<Props> = ({ next }) => {
             : t('run-dkg.generating-header')}
         </Heading>
       )}
-    </VStack>
+    </Flex>
   );
 };

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -173,7 +173,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
   };
 
   return (
-    <Flex direction='column' gap={8} justify='start' align='start'>
+    <Flex direction='column' gap={10} justify='start' align='start'>
       <FormGroup>
         <FormControl>
           <FormLabel>{t('set-config.guardian-name')}</FormLabel>

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
-  VStack,
+  Flex,
   FormControl,
   FormLabel,
   FormHelperText,
@@ -173,7 +173,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
   };
 
   return (
-    <VStack gap={8} justify='start' align='start'>
+    <Flex direction='column' gap={8} justify='start' align='start'>
       <FormGroup>
         <FormControl>
           <FormLabel>{t('set-config.guardian-name')}</FormLabel>
@@ -292,6 +292,6 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
           {t('common.next')}
         </Button>
       </div>
-    </VStack>
+    </Flex>
   );
 };

--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -189,7 +189,7 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
 
   if (error) {
     return (
-      <Flex direction='column' gap={4}>
+      <Flex direction='column' gap={6}>
         <Heading size='sm'>{t('verify-guardians.error')}</Heading>
         <Text color={theme.colors.red[500]}>{error}</Text>
       </Flex>
@@ -198,7 +198,7 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
     return <Spinner />;
   } else if (numPeers === 1) {
     return (
-      <Flex direction='column' gap={8} justify='center' align='center'>
+      <Flex direction='column' gap={10} justify='center' align='center'>
         <CircularProgress
           isIndeterminate
           color={theme.colors.blue[400]}
@@ -209,7 +209,7 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
     );
   } else {
     return (
-      <Flex direction='column' gap={8} justify='start' align='start'>
+      <Flex direction='column' gap={10} justify='start' align='start'>
         <FormGroup>
           <FormControl>
             <FormLabel>{t('verify-guardians.verification-code')}</FormLabel>
@@ -225,7 +225,7 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
           columns={tableColumns}
           rows={tableRows}
         />
-        <Flex direction='row' mt={4}>
+        <Flex direction='row' mt={4} gap={2}>
           <Button
             isDisabled={!verifiedConfigs}
             isLoading={isStarting}

--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -4,15 +4,14 @@ import {
   FormControl,
   FormLabel,
   FormHelperText,
+  Flex,
   Icon,
-  VStack,
   Heading,
   Text,
   Spinner,
   Input,
   Tag,
   useTheme,
-  HStack,
   CircularProgress,
 } from '@chakra-ui/react';
 import { CopyInput, FormGroup, Table } from '@fedimint/ui';
@@ -190,27 +189,27 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
 
   if (error) {
     return (
-      <VStack gap={4}>
+      <Flex direction='column' gap={4}>
         <Heading size='sm'>{t('verify-guardians.error')}</Heading>
         <Text color={theme.colors.red[500]}>{error}</Text>
-      </VStack>
+      </Flex>
     );
   } else if (!peersWithHash) {
     return <Spinner />;
   } else if (numPeers === 1) {
     return (
-      <VStack gap={8} justify='center' align='center'>
+      <Flex direction='column' gap={8} justify='center' align='center'>
         <CircularProgress
           isIndeterminate
           color={theme.colors.blue[400]}
           size='200px'
         />
         <Heading size='sm'>{t('verify-guardians.starting-consensus')}</Heading>
-      </VStack>
+      </Flex>
     );
   } else {
     return (
-      <VStack gap={8} justify='start' align='start'>
+      <Flex direction='column' gap={8} justify='start' align='start'>
         <FormGroup>
           <FormControl>
             <FormLabel>{t('verify-guardians.verification-code')}</FormLabel>
@@ -226,7 +225,7 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
           columns={tableColumns}
           rows={tableRows}
         />
-        <HStack mt={4}>
+        <Flex direction='row' mt={4}>
           <Button
             isDisabled={!verifiedConfigs}
             isLoading={isStarting}
@@ -236,8 +235,8 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
             {t('common.next')}
           </Button>
           <WaitingForVerification verifiedConfigs={verifiedConfigs} />
-        </HStack>
-      </VStack>
+        </Flex>
+      </Flex>
     );
   }
 };

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Box, Button, Text, Heading, Icon, VStack } from '@chakra-ui/react';
+import { Box, Button, Text, Heading, Icon, Flex } from '@chakra-ui/react';
 import { ReactComponent as ArrowLeftIcon } from '../assets/svgs/arrow-left.svg';
 import { useTranslation } from '@fedimint/utils';
 import { useSetupContext } from '../hooks';
@@ -102,11 +102,11 @@ export const FederationSetup: React.FC = () => {
   }
 
   return (
-    <VStack gap={8} align='start'>
+    <Flex direction='column' gap={8} align='start'>
       {progressIdx === 0 || !progressIdx ? null : (
         <SetupStepper setupProgress={progressIdx} isHost={isHost} />
       )}
-      <VStack align='start' gap={2}>
+      <Flex direction='column' align='start' gap={2}>
         {prevProgress && canGoBack && (
           <Button
             variant='link'
@@ -126,10 +126,10 @@ export const FederationSetup: React.FC = () => {
             {subtitle}
           </Text>
         )}
-      </VStack>
+      </Flex>
       <Box mt={10} width='100%'>
         {content}
       </Box>
-    </VStack>
+    </Flex>
   );
 };

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -102,11 +102,11 @@ export const FederationSetup: React.FC = () => {
   }
 
   return (
-    <Flex direction='column' gap={8} align='start'>
+    <Flex direction='column' gap={10} align='start'>
       {progressIdx === 0 || !progressIdx ? null : (
         <SetupStepper setupProgress={progressIdx} isHost={isHost} />
       )}
-      <Flex direction='column' align='start' gap={2}>
+      <Flex direction='column' align='start' gap={4}>
         {prevProgress && canGoBack && (
           <Button
             variant='link'

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -127,7 +127,7 @@ export const FederationSetup: React.FC = () => {
           </Text>
         )}
       </Flex>
-      <Box mt={10} width='100%'>
+      <Box mt={2} width='100%'>
         {content}
       </Box>
     </Flex>

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -23,14 +23,14 @@ module.exports = {
     'no-restricted-imports': [
       'error',
       {
-        name: 'HStack',
-        message:
-          "Please use <Flex direction='row'> instead as it does not add any additional styling, where as HStack adds 0.5 rem margin to it's children.",
-      },
-      {
-        name: 'VStack',
-        message:
-          "Please use <Flex direction='column'> instead as it does not add any additional styling, where as VStack adds 0.5 rem margin to it's children.",
+        paths: [
+          {
+            name: '@chakra-ui/react',
+            importNames: ['HStack', 'VStack'],
+            message:
+              "Please use <Flex direction='row|column'> instead as it does not add any additional styling, where as HStack/VStack components add 0.5 rem margin to their children, leading to inconsistent styling.",
+          },
+        ],
       },
     ],
   },

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -20,6 +20,19 @@ module.exports = {
       { avoidEscape: true, allowTemplateLiterals: true },
     ],
     semi: ['error', 'always', { omitLastInOneLineBlock: true }],
+    'no-restricted-imports': [
+      'error',
+      {
+        name: 'HStack',
+        message:
+          "Please use <Flex direction='row'> instead as it does not add any additional styling, where as HStack adds 0.5 rem margin to it's children.",
+      },
+      {
+        name: 'VStack',
+        message:
+          "Please use <Flex direction='column'> instead as it does not add any additional styling, where as VStack adds 0.5 rem margin to it's children.",
+      },
+    ],
   },
   settings: {
     react: {

--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -1,1 +1,1 @@
-module.exports = require("@fedimint/eslint-config");
+module.exports = require('@fedimint/eslint-config');

--- a/packages/ui/src/CopyInput.tsx
+++ b/packages/ui/src/CopyInput.tsx
@@ -27,8 +27,6 @@ export const CopyInput: React.FC<CopyInputProps> = ({
     md: '100px',
     sm: '96px',
   }[size];
-  // Height is input - 2px to account for borders
-  const buttonHeight = theme.components.Input.sizes[size].height - 2;
 
   return (
     <InputGroup width='100%' size={size}>

--- a/packages/ui/src/FormGroup.tsx
+++ b/packages/ui/src/FormGroup.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { VStack } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 
 export const FormGroup: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => (
-  <VStack gap={4} align='start' width='100%' maxWidth={320}>
+  <Flex direction='column' gap={4} align='start' width='100%' maxWidth={320}>
     {children}
-  </VStack>
+  </Flex>
 );

--- a/packages/ui/src/FormGroup.tsx
+++ b/packages/ui/src/FormGroup.tsx
@@ -4,7 +4,7 @@ import { Flex } from '@chakra-ui/react';
 export const FormGroup: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => (
-  <Flex direction='column' gap={4} align='start' width='100%' maxWidth={320}>
+  <Flex direction='column' gap={6} align='start' width='100%' maxWidth={320}>
     {children}
   </Flex>
 );

--- a/packages/ui/src/RadioButtonGroup.tsx
+++ b/packages/ui/src/RadioButtonGroup.tsx
@@ -1,13 +1,5 @@
 import React from 'react';
-import {
-  VStack,
-  HStack,
-  Button,
-  Icon,
-  Text,
-  Flex,
-  useTheme,
-} from '@chakra-ui/react';
+import { Button, Icon, Text, Flex, useTheme } from '@chakra-ui/react';
 
 export interface RadioButtonOption<T extends string | number> {
   icon: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
@@ -70,7 +62,7 @@ export function RadioButtonGroup<T extends string | number>({
             sx={isActive ? activeStyles : defaultStyles}
             role='group'
           >
-            <HStack maxWidth='100%' gap={3} align='start'>
+            <Flex direction='row' maxWidth='100%' gap={3} align='start'>
               <Flex
                 width='40px'
                 height='40px'
@@ -83,7 +75,13 @@ export function RadioButtonGroup<T extends string | number>({
               >
                 <Icon as={option.icon} />
               </Flex>
-              <VStack align='start' flex={1} minWidth={0} wrap='wrap'>
+              <Flex
+                direction='column'
+                align='start'
+                flex={1}
+                minWidth={0}
+                wrap='wrap'
+              >
                 <Text
                   fontWeight='medium'
                   color={isActive ? theme.colors.blue[800] : undefined}
@@ -98,7 +96,7 @@ export function RadioButtonGroup<T extends string | number>({
                 >
                   {option.description}
                 </Text>
-              </VStack>
+              </Flex>
               <Flex
                 align='center'
                 justify='center'
@@ -135,7 +133,7 @@ export function RadioButtonGroup<T extends string | number>({
               >
                 {isActive && activeIcon && <Icon as={activeIcon} />}
               </Flex>
-            </HStack>
+            </Flex>
           </Button>
         );
       })}

--- a/packages/ui/src/RadioButtonGroup.tsx
+++ b/packages/ui/src/RadioButtonGroup.tsx
@@ -62,7 +62,7 @@ export function RadioButtonGroup<T extends string | number>({
             sx={isActive ? activeStyles : defaultStyles}
             role='group'
           >
-            <Flex direction='row' maxWidth='100%' gap={3} align='start'>
+            <Flex direction='row' maxWidth='100%' gap={5} align='start'>
               <Flex
                 width='40px'
                 height='40px'
@@ -81,6 +81,7 @@ export function RadioButtonGroup<T extends string | number>({
                 flex={1}
                 minWidth={0}
                 wrap='wrap'
+                gap={2}
               >
                 <Text
                   fontWeight='medium'


### PR DESCRIPTION
Fixes #198 

The PR accomplishes the following:
- Remove all the instances of the `HStack` and `VStack` components from the codebase and replace the same with `Flex` with the same gap properties. 
- Add `ESLint` rules to ban these components, and add suggestion messages to use `Flex` instead. 