### PR TITLE
fix: configure gateway ui env from devimint env

### DIFF
--- a/mprocs-nix-gateway.yml
+++ b/mprocs-nix-gateway.yml
@@ -23,9 +23,7 @@ procs:
   devimint:
     shell: tail -n +0 -F $FM_LOGS_DIR/devimint.log
   gateway-ui:
-    shell: yarn dev:gateway-ui
+    shell: bash --init-file scripts/mprocs-nix-gateway.sh
     env:
       PORT: '3004'
-      REACT_APP_FM_GATEWAY_API: 'http://127.0.0.1:8175'
-      REACT_APP_FM_GATEWAY_PASSWORD: 'theresnosecondbest'
       BROWSER: none

--- a/scripts/mprocs-nix-gateway.sh
+++ b/scripts/mprocs-nix-gateway.sh
@@ -1,0 +1,19 @@
+# shellcheck shell=bash
+
+eval "$(devimint env)"
+
+echo Waiting for devimint to start up fedimint and gateway
+
+STATUS="$(devimint wait)"
+if [ "$STATUS" = "ERROR" ]
+then
+    echo "fedimint didn't start correctly"
+    echo "See other panes for errors"
+    exit 1
+fi
+
+# Conigure UI env from devimint env
+export REACT_APP_FM_GATEWAY_API=$FM_GATEWAY_API_ADDR
+export REACT_APP_FM_GATEWAY_PASSWORD=$FM_GATEWAY_PASSWORD
+
+yarn dev:gateway-ui

--- a/scripts/mprocs-user-shell.sh
+++ b/scripts/mprocs-user-shell.sh
@@ -2,7 +2,7 @@
 
 eval "$(devimint env)"
 
-echo Waiting for fedimint start
+echo Waiting for devimint to start up fedimint
 
 STATUS="$(devimint wait)"
 if [ "$STATUS" = "ERROR" ]


### PR DESCRIPTION
When starting up gateway ui in devimint scenarios, we should configure REACT_APP_FM_GATEWAY_API and REACT_APP_FM_GATEWAY_PASSWORD to values set by devimint