### PR TITLE
fix: don't cache results of lint and test

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": [
+    "packages/eslint-config/*.js",
+    "packages/eslint-config/*.json",
+    "packages/tsconfig/*.json"
+  ],
   "pipeline": {
     "build": {
       "outputs": ["build/**", "dist/**"],


### PR DESCRIPTION
Invalidates turbo cache on `@fedimint/eslint-config` and `@fedimint/tsconfig` dev dependency changes. This fixes a bug where `turbo lint` would require `turbo build` for the latest lint rules to take effect.

ref: https://turbo.build/repo/docs/core-concepts/caching