### PR TITLE
fix(guardian-ui): add getEnv utility for avoiding compiler env var optimizations

### DIFF
--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -11,6 +11,7 @@ import {
   PeerHashMap,
   ModulesConfigResponse,
 } from './types';
+import { getEnv } from './utils/env';
 
 export interface SocketAndAuthInterface {
   // WebSocket methods
@@ -58,7 +59,7 @@ class BaseGuardianApi
     }
 
     this.connectPromise = new Promise((resolve, reject) => {
-      const websocketUrl = process.env.REACT_APP_FM_CONFIG_API;
+      const websocketUrl = getEnv().FM_CONFIG_API;
 
       if (!websocketUrl) {
         throw new Error('REACT_APP_FM_CONFIG_API not set');

--- a/apps/guardian-ui/src/components/TermsOfService.tsx
+++ b/apps/guardian-ui/src/components/TermsOfService.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Button, Flex, Textarea } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
+import { getEnv } from '../utils/env';
 
 interface Props {
   next(): void;
@@ -8,7 +9,7 @@ interface Props {
 
 export const TermsOfService: React.FC<Props> = ({ next }) => {
   const { t } = useTranslation();
-  const tos = process.env.REACT_APP_TOS;
+  const tos = getEnv().TOS;
 
   // If this was mistakenly rendered with no ToS, just instantly agree and continue.
   useEffect(() => {
@@ -17,7 +18,7 @@ export const TermsOfService: React.FC<Props> = ({ next }) => {
 
   return (
     <Flex direction='column' gap={4} maxWidth={660}>
-      <Textarea value={process.env.REACT_APP_TOS} rows={14} readOnly />
+      <Textarea value={tos} rows={14} readOnly />
       <Button onClick={next}>{t('terms-of-service.agree-and-continue')}</Button>
     </Flex>
   );

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -12,6 +12,7 @@ import { VerifyGuardians } from '../components/VerifyGuardians';
 import { SetupComplete } from '../components/SetupComplete';
 import { SetupProgress as SetupStepper } from '../components/SetupProgress';
 import { TermsOfService } from '../components/TermsOfService';
+import { getEnv } from '../utils/env';
 
 const PROGRESS_ORDER: SetupProgress[] = [
   SetupProgress.Start,
@@ -28,9 +29,7 @@ export const FederationSetup: React.FC = () => {
     state: { progress, role },
     dispatch,
   } = useSetupContext();
-  const [needsTosAgreement, setNeedsTosAgreement] = useState(
-    !!process.env.REACT_APP_TOS
-  );
+  const [needsTosAgreement, setNeedsTosAgreement] = useState(!!getEnv().TOS);
 
   const isHost = role === GuardianRole.Host;
   const progressIdx = PROGRESS_ORDER.indexOf(progress);

--- a/apps/guardian-ui/src/utils/env.ts
+++ b/apps/guardian-ui/src/utils/env.ts
@@ -1,0 +1,15 @@
+export function getEnv() {
+  // This is a hack to get around react-scripts inlining environment variable
+  // checks. Boolean conditionals get reduced to `!0` and `!1` which breaks
+  // environment variable replacements from `replace-react-env.js`.
+  // Note that if you actually WANT that inlining, you should use `process.env`
+  // directly in your code, NOT `getEnv()`
+  // See https://create-react-app.dev/docs/adding-custom-environment-variables/ for more info
+  // See https://github.com/fedimint/ui/issues/224 for the long-term fix for configuration
+  return JSON.parse(
+    JSON.stringify({
+      FM_CONFIG_API: process.env.REACT_APP_FM_CONFIG_API,
+      TOS: process.env.REACT_APP_TOS,
+    })
+  );
+}


### PR DESCRIPTION
Closes #248

### What This Does

Stringifies & parses env to avoid react-scripts compiler optimizations of environment variables. See comment in `guardian-ui/utils/env.ts` for more information on why this was done and how it works.

This bit of code is just a hack until #224 is implemented, since that wouldn't get any of the compiler optimizations since the config would be loaded dynamically.