### PR TITLE
feat(guardian-ui): meta fields

### DIFF
--- a/apps/guardian-ui/src/assets/svgs/modules.svg
+++ b/apps/guardian-ui/src/assets/svgs/modules.svg
@@ -1,3 +1,4 @@
-<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M6.42857 10.3652L2.25 12.6152L6.42857 14.8652M6.42857 10.3652L12 13.3652L17.5714 10.3652M6.42857 10.3652L2.25 8.11523L12 2.86523L21.75 8.11523L17.5714 10.3652M17.5714 10.3652L21.75 12.6152L17.5714 14.8652M17.5714 14.8652L21.75 17.1152L12 22.3652L2.25 17.1152L6.42857 14.8652M17.5714 14.8652L12 17.8652L6.42857 14.8652" stroke="#9CA3AF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" fill="none" viewBox="0 0 24 25">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+    d="m6.429 10.365-4.179 2.25 4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 8.115 12 2.865l9.75 5.25-4.179 2.25m0 0 4.179 2.25-4.179 2.25m0 0 4.179 2.25-9.75 5.25-9.75-5.25 4.179-2.25m11.142 0-5.571 3-5.571-3" />
 </svg>

--- a/apps/guardian-ui/src/assets/svgs/plus.svg
+++ b/apps/guardian-ui/src/assets/svgs/plus.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+  stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="12" y1="5" x2="12" y2="19"></line>
+  <line x1="5" y1="12" x2="19" y2="12"></line>
+</svg>

--- a/apps/guardian-ui/src/assets/svgs/trash.svg
+++ b/apps/guardian-ui/src/assets/svgs/trash.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+  stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+  class="feather feather-trash">
+  <polyline points="3 6 5 6 21 6"></polyline>
+  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+</svg>

--- a/apps/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/apps/guardian-ui/src/components/ConnectGuardians.tsx
@@ -105,7 +105,10 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
         } catch {
           /* no-op, use value as string */
         }
-        rows.push({ label: `Meta - ${key}`, value });
+        rows.push({
+          label: t('connect-guardians.meta-field-key', { key }),
+          value,
+        });
       });
 
     content = (

--- a/apps/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/apps/guardian-ui/src/components/ConnectGuardians.tsx
@@ -73,7 +73,7 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
     );
   } else {
     // TODO: Consider making this more dynamic, work with unknown modules etc.
-    const rows = [
+    const rows: { label: string; value: React.ReactNode }[] = [
       {
         label: 'Federation name',
         value: configGenParams.meta?.federation_name,
@@ -90,6 +90,24 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
       },
     ];
 
+    // Render each meta key as its own row
+    Object.keys(configGenParams.meta || {})
+      .filter((key) => key !== 'federation_name')
+      .forEach((key) => {
+        let value: React.ReactNode = configGenParams.meta?.[key];
+        if (!value) return;
+        try {
+          value = (
+            <pre style={{ maxHeight: 200, overflow: 'auto', maxWidth: '100%' }}>
+              {JSON.stringify(JSON.parse(value as string), null, 2)}
+            </pre>
+          );
+        } catch {
+          /* no-op, use value as string */
+        }
+        rows.push({ label: `Meta - ${key}`, value });
+      });
+
     content = (
       <Flex
         direction='column'
@@ -97,14 +115,15 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
         justify='start'
         align='start'
         width='100%'
-        maxWidth={400}
       >
         <TableContainer width='100%'>
           <ChakraTable variant='simple'>
             <Tbody>
               {rows.map(({ label, value }) => (
                 <Tr key={label}>
-                  <Td fontWeight='semibold'>{label}</Td>
+                  <Td fontWeight='semibold' verticalAlign='top'>
+                    {label}
+                  </Td>
                   <Td>{value}</Td>
                 </Tr>
               ))}

--- a/apps/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/apps/guardian-ui/src/components/ConnectGuardians.tsx
@@ -190,7 +190,7 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
       gap={10}
     >
       {content}
-      {peerTableRows.length && (
+      {!!peerTableRows.length && (
         <Table
           title={t('connect-guardians.table-title')}
           description={t('connect-guardians.table-description')}

--- a/apps/guardian-ui/src/components/MetaFieldFormControl.tsx
+++ b/apps/guardian-ui/src/components/MetaFieldFormControl.tsx
@@ -11,6 +11,7 @@ import {
 import React from 'react';
 import { ReactComponent as TrashIcon } from '../assets/svgs/trash.svg';
 import { ReactComponent as PlusIcon } from '../assets/svgs/plus.svg';
+import { useTranslation, Trans } from '@fedimint/utils';
 
 interface Props {
   metaFields: [string, string][];
@@ -21,6 +22,7 @@ export const MetaFieldFormControl: React.FC<Props> = ({
   metaFields,
   onChangeMetaFields,
 }) => {
+  const { t } = useTranslation();
   const theme = useTheme();
 
   const derivedMetaKeys = ['federation_name'];
@@ -43,23 +45,26 @@ export const MetaFieldFormControl: React.FC<Props> = ({
     <FormControl>
       <Flex direction='column' gap={3}>
         <FormHelperText mt={0} mb={2}>
-          Additional configuration sent to fedimint clients. See{' '}
-          <Link
-            href='https://github.com/fedimint/fedimint/blob/master/docs/meta_fields/README.md'
-            target='_blank'
-            rel='noopener noreferrer'
-            color={theme.colors.blue[600]}
-          >
-            documentation
-          </Link>{' '}
-          for more information.
+          <Trans
+            i18nKey='set-config.meta-fields-description'
+            components={{
+              docs: (
+                <Link
+                  href='https://github.com/fedimint/fedimint/blob/master/docs/meta_fields/README.md'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  color={theme.colors.blue[600]}
+                />
+              ),
+            }}
+          />
         </FormHelperText>
         {metaFields.map(([key, value], idx) => {
           const isDerived = derivedMetaKeys.includes(key);
           return (
             <Flex gap={3} key={idx}>
               <Input
-                placeholder='Key'
+                placeholder={t('set-config.meta-fields-key')}
                 value={key}
                 disabled={isDerived}
                 onChange={(ev) =>
@@ -67,7 +72,7 @@ export const MetaFieldFormControl: React.FC<Props> = ({
                 }
               />
               <Input
-                placeholder={isDerived ? '' : 'Value'}
+                placeholder={isDerived ? '' : t('set-config.meta-fields-value')}
                 value={value}
                 disabled={isDerived}
                 onChange={(ev) =>
@@ -83,7 +88,7 @@ export const MetaFieldFormControl: React.FC<Props> = ({
                   width={'42px'}
                   height={'42px'}
                   fontSize={12}
-                  aria-label='Remove'
+                  aria-label={t('common.remove')}
                   colorScheme='red'
                   color={theme.colors.gray[300]}
                   _hover={{ color: theme.colors.red[500] }}
@@ -99,7 +104,7 @@ export const MetaFieldFormControl: React.FC<Props> = ({
           variant='outline'
           onClick={handleAddMetaField}
         >
-          Add another
+          {t('set-config.meta-fields-add-another')}
         </Button>
       </Flex>
     </FormControl>

--- a/apps/guardian-ui/src/components/MetaFieldFormControl.tsx
+++ b/apps/guardian-ui/src/components/MetaFieldFormControl.tsx
@@ -1,0 +1,106 @@
+import {
+  Button,
+  Collapse,
+  Flex,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  IconButton,
+  Input,
+  Link,
+  useTheme,
+} from '@chakra-ui/react';
+import React, { useState } from 'react';
+import { ReactComponent as TrashIcon } from '../assets/svgs/trash.svg';
+
+interface Props {
+  metaFields: [string, string][];
+  onChangeMetaFields: (value: [string, string][]) => void;
+}
+
+export const MetaFieldFormControl: React.FC<Props> = ({
+  metaFields,
+  onChangeMetaFields,
+}) => {
+  const theme = useTheme();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const derivedMetaKeys = ['federation_name'];
+
+  const handleChangeMetaField = (key: string, value: string, index: number) => {
+    const newFields = [...metaFields];
+    newFields[index] = [key, value];
+    onChangeMetaFields(newFields);
+  };
+
+  const handleRemoveMetaField = (idx: number) => {
+    onChangeMetaFields(metaFields.filter((_, i) => i !== idx));
+  };
+
+  const handleAddMetaField = () => {
+    onChangeMetaFields([...metaFields, ['', '']]);
+  };
+
+  return (
+    <FormControl>
+      <FormLabel onClick={() => setIsOpen((s) => !s)} cursor='pointer'>
+        Meta fields
+      </FormLabel>
+      <Collapse in={isOpen}>
+        <Flex direction='column' gap={3}>
+          <FormHelperText mt={0} mb={2}>
+            Configuration sent to federation clients. See{' '}
+            <Link
+              href='https://github.com/fedimint/fedimint/blob/master/docs/meta_fields/README.md'
+              target='_blank'
+              rel='noopener noreferrer'
+              color={theme.colors.blue[600]}
+            >
+              documentation
+            </Link>{' '}
+            for more information.
+          </FormHelperText>
+          {metaFields.map(([key, value], idx) => {
+            const isDerived = derivedMetaKeys.includes(key);
+            return (
+              <Flex gap={3} key={idx}>
+                <Input
+                  placeholder='Key'
+                  value={key}
+                  disabled={isDerived}
+                  onChange={(ev) =>
+                    handleChangeMetaField(ev.target.value, value, idx)
+                  }
+                />
+                <Input
+                  placeholder='Value'
+                  value={value}
+                  disabled={isDerived}
+                  onChange={(ev) =>
+                    handleChangeMetaField(key, ev.target.value, idx)
+                  }
+                />
+                {!isDerived && (
+                  <IconButton
+                    position='absolute'
+                    left='100%'
+                    transform='translate(8px, 4px)'
+                    variant='ghost'
+                    colorScheme='red'
+                    size='xs'
+                    aria-label='Remove'
+                    icon={<TrashIcon />}
+                    onClick={() => handleRemoveMetaField(idx)}
+                  />
+                )}
+              </Flex>
+            );
+          })}
+          <Button variant='outline' onClick={handleAddMetaField}>
+            Add another
+          </Button>
+        </Flex>
+      </Collapse>
+    </FormControl>
+  );
+};

--- a/apps/guardian-ui/src/components/MetaFieldFormControl.tsx
+++ b/apps/guardian-ui/src/components/MetaFieldFormControl.tsx
@@ -1,17 +1,16 @@
 import {
   Button,
-  Collapse,
   Flex,
   FormControl,
   FormHelperText,
-  FormLabel,
   IconButton,
   Input,
   Link,
   useTheme,
 } from '@chakra-ui/react';
-import React, { useState } from 'react';
+import React from 'react';
 import { ReactComponent as TrashIcon } from '../assets/svgs/trash.svg';
+import { ReactComponent as PlusIcon } from '../assets/svgs/plus.svg';
 
 interface Props {
   metaFields: [string, string][];
@@ -23,7 +22,6 @@ export const MetaFieldFormControl: React.FC<Props> = ({
   onChangeMetaFields,
 }) => {
   const theme = useTheme();
-  const [isOpen, setIsOpen] = useState(false);
 
   const derivedMetaKeys = ['federation_name'];
 
@@ -43,64 +41,67 @@ export const MetaFieldFormControl: React.FC<Props> = ({
 
   return (
     <FormControl>
-      <FormLabel onClick={() => setIsOpen((s) => !s)} cursor='pointer'>
-        Meta fields
-      </FormLabel>
-      <Collapse in={isOpen}>
-        <Flex direction='column' gap={3}>
-          <FormHelperText mt={0} mb={2}>
-            Configuration sent to federation clients. See{' '}
-            <Link
-              href='https://github.com/fedimint/fedimint/blob/master/docs/meta_fields/README.md'
-              target='_blank'
-              rel='noopener noreferrer'
-              color={theme.colors.blue[600]}
-            >
-              documentation
-            </Link>{' '}
-            for more information.
-          </FormHelperText>
-          {metaFields.map(([key, value], idx) => {
-            const isDerived = derivedMetaKeys.includes(key);
-            return (
-              <Flex gap={3} key={idx}>
-                <Input
-                  placeholder='Key'
-                  value={key}
-                  disabled={isDerived}
-                  onChange={(ev) =>
-                    handleChangeMetaField(ev.target.value, value, idx)
-                  }
+      <Flex direction='column' gap={3}>
+        <FormHelperText mt={0} mb={2}>
+          Additional configuration sent to fedimint clients. See{' '}
+          <Link
+            href='https://github.com/fedimint/fedimint/blob/master/docs/meta_fields/README.md'
+            target='_blank'
+            rel='noopener noreferrer'
+            color={theme.colors.blue[600]}
+          >
+            documentation
+          </Link>{' '}
+          for more information.
+        </FormHelperText>
+        {metaFields.map(([key, value], idx) => {
+          const isDerived = derivedMetaKeys.includes(key);
+          return (
+            <Flex gap={3} key={idx}>
+              <Input
+                placeholder='Key'
+                value={key}
+                disabled={isDerived}
+                onChange={(ev) =>
+                  handleChangeMetaField(ev.target.value, value, idx)
+                }
+              />
+              <Input
+                placeholder={isDerived ? '' : 'Value'}
+                value={value}
+                disabled={isDerived}
+                onChange={(ev) =>
+                  handleChangeMetaField(key, ev.target.value, idx)
+                }
+              />
+              {!isDerived && (
+                <IconButton
+                  position='absolute'
+                  left='100%'
+                  variant='ghost'
+                  size='xs'
+                  width={'42px'}
+                  height={'42px'}
+                  fontSize={12}
+                  aria-label='Remove'
+                  colorScheme='red'
+                  color={theme.colors.gray[300]}
+                  _hover={{ color: theme.colors.red[500] }}
+                  icon={<TrashIcon height={20} />}
+                  onClick={() => handleRemoveMetaField(idx)}
                 />
-                <Input
-                  placeholder='Value'
-                  value={value}
-                  disabled={isDerived}
-                  onChange={(ev) =>
-                    handleChangeMetaField(key, ev.target.value, idx)
-                  }
-                />
-                {!isDerived && (
-                  <IconButton
-                    position='absolute'
-                    left='100%'
-                    transform='translate(8px, 4px)'
-                    variant='ghost'
-                    colorScheme='red'
-                    size='xs'
-                    aria-label='Remove'
-                    icon={<TrashIcon />}
-                    onClick={() => handleRemoveMetaField(idx)}
-                  />
-                )}
-              </Flex>
-            );
-          })}
-          <Button variant='outline' onClick={handleAddMetaField}>
-            Add another
-          </Button>
-        </Flex>
-      </Collapse>
+              )}
+            </Flex>
+          );
+        })}
+        <Button
+          leftIcon={<PlusIcon height={20} width={20} />}
+          variant='outline'
+          onClick={handleAddMetaField}
+        >
+          Add another
+        </Button>
+      </Flex>
     </FormControl>
   );
 };

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -17,6 +17,7 @@ import { useSetupContext } from '../hooks';
 import { BitcoinRpc, ConfigGenParams, GuardianRole, Network } from '../types';
 import { ReactComponent as FedimintLogo } from '../assets/svgs/fedimint.svg';
 import { ReactComponent as BitcoinLogo } from '../assets/svgs/bitcoin.svg';
+import { ReactComponent as ModulesIcon } from '../assets/svgs/modules.svg';
 import { ReactComponent as ArrowRightIcon } from '../assets/svgs/arrow-right.svg';
 import {
   formatApiErrorMessage,
@@ -251,10 +252,6 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
                 setNumPeers(value);
               }}
             />
-            <MetaFieldFormControl
-              metaFields={metaFields}
-              onChangeMetaFields={setMetaFields}
-            />
           </FormGroup>
         )}
         <FormGroup>
@@ -301,6 +298,15 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
             <FormHelperText>{t('set-config.set-rpc-help')}</FormHelperText>
           </FormControl>
         </FormGroup>
+        {isHost && (
+          <FormGroup maxWidth={470}>
+            <FormGroupHeading icon={ModulesIcon} title='Meta fields' />
+            <MetaFieldFormControl
+              metaFields={metaFields}
+              onChangeMetaFields={setMetaFields}
+            />
+          </FormGroup>
+        )}
       </>
       {error && (
         <Text color={theme.colors.red[500]} mt={4}>

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -300,7 +300,10 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
         </FormGroup>
         {isHost && (
           <FormGroup maxWidth={470}>
-            <FormGroupHeading icon={ModulesIcon} title='Meta fields' />
+            <FormGroupHeading
+              icon={ModulesIcon}
+              title={t('set-config.meta-fields')}
+            />
             <MetaFieldFormControl
               metaFields={metaFields}
               onChangeMetaFields={setMetaFields}

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -25,8 +25,9 @@ import {
   removeConfigGenModuleConsensusParams,
 } from '../utils/api';
 import { ModuleKind } from '../types';
-import { isValidNumber } from '../utils/validators';
+import { isValidMeta, isValidNumber } from '../utils/validators';
 import { NumberFormControl } from './NumberFormControl';
+import { MetaFieldFormControl } from './MetaFieldFormControl';
 
 interface Props {
   next: () => void;
@@ -55,6 +56,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
     stateNumPeers ? stateNumPeers.toString() : '4'
   );
   const [federationName, setFederationName] = useState('');
+  const [metaFields, setMetaFields] = useState<[string, string][]>([['', '']]);
   const [blockConfirmations, setBlockConfirmations] = useState('');
   const [network, setNetwork] = useState('');
   const [bitcoinRpc, setBitcoinRpc] = useState<BitcoinRpc>({
@@ -68,6 +70,9 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
     const initStateFromParams = (params: ConfigGenParams) => {
       setDefaultParams(params);
       setFederationName(params.meta?.federation_name || '');
+
+      const meta = { federation_name: '', ...params.meta };
+      setMetaFields(Object.entries(meta));
 
       const mintModule = getModuleParamsFromConfig(params, ModuleKind.Mint);
       if (mintModule?.consensus?.mint_amounts) {
@@ -111,9 +116,22 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
           federationName &&
           isValidNumber(numPeers, 4) &&
           isValidNumber(blockConfirmations, 1, 200) &&
+          isValidMeta(metaFields) &&
           network
       )
     : Boolean(myName && password && hostServerUrl);
+
+  const handleChangeFederationName = (
+    ev: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const newName = ev.currentTarget.value;
+    setFederationName(newName);
+    setMetaFields((prev) =>
+      prev.map(([key, val]) =>
+        key === 'federation_name' ? [key, newName] : [key, val]
+      )
+    );
+  };
 
   const handleNext = async () => {
     setError(undefined);
@@ -149,7 +167,10 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
           password,
           configs: {
             numPeers: parseInt(numPeers, 10),
-            meta: { ...defaultParams.meta, federation_name: federationName },
+            meta: metaFields.reduce(
+              (acc, [key, val]) => ({ ...acc, [key]: val }),
+              {}
+            ),
             modules: moduleConfigs,
           },
         });
@@ -218,7 +239,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
               <FormLabel>{t('set-config.federation-name')}</FormLabel>
               <Input
                 value={federationName}
-                onChange={(ev) => setFederationName(ev.currentTarget.value)}
+                onChange={handleChangeFederationName}
               />
             </FormControl>
             <NumberFormControl
@@ -229,6 +250,10 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
               onChange={(value) => {
                 setNumPeers(value);
               }}
+            />
+            <MetaFieldFormControl
+              metaFields={metaFields}
+              onChangeMetaFields={setMetaFields}
             />
           </FormGroup>
         )}

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -4,7 +4,8 @@
     "next": "Next",
     "back": "Back",
     "error": "Something went wrong.",
-    "unknown": "Unknown"
+    "unknown": "Unknown",
+    "remove": "Remove"
   },
   "connect-guardians": {
     "invite-guardians": "Invite Followers",
@@ -14,7 +15,8 @@
     "pending": "Pending",
     "not-joined": "Not joined",
     "table-title": "Federation Guardians",
-    "table-description": "Guardians will be confirmed here once they confirm Federation settings."
+    "table-description": "Guardians will be confirmed here once they confirm Federation settings.",
+    "meta-field-key": "Meta field - {{key}}"
   },
   "federation-dashboard": {
     "invite-members": "Invite members",
@@ -96,7 +98,12 @@
     "error-valid-number": "Please input a valid number.",
     "error-valid-min": "Please input a number of at least {{min}}.",
     "error-valid-max": "Please input a number of at most {{max}}.",
-    "error-valid-min-max": "Please input a number between {{min}} and {{max}}."
+    "error-valid-min-max": "Please input a number between {{min}} and {{max}}.",
+    "meta-fields": "Meta fields",
+    "meta-fields-description": "Additional configuration sent to fedimint clients. See <docs>documentation</docs> or more information.",
+    "meta-fields-key": "Meta key",
+    "meta-fields-value": "Value",
+    "meta-fields-add-another": "Add another"
   },
   "setup": {
     "progress": {

--- a/apps/guardian-ui/src/types/api.ts
+++ b/apps/guardian-ui/src/types/api.ts
@@ -75,7 +75,10 @@ interface ApiEndpoint {
   url: string;
 }
 
-export type MetaConfig = { federation_name?: string };
+export type MetaConfig = { federation_name?: string } & Record<
+  string,
+  string | undefined
+>;
 
 export interface ClientConfig {
   consensus_version: number;

--- a/apps/guardian-ui/src/utils/validators.ts
+++ b/apps/guardian-ui/src/utils/validators.ts
@@ -5,3 +5,7 @@ export const isValidNumber = (value: string, min?: number, max?: number) => {
   if (typeof max === 'number' && int > max) return false;
   return true;
 };
+
+export const isValidMeta = (meta: [string, string][]) => {
+  return meta.every(([key, value]) => key && value);
+};

--- a/packages/ui/src/FormGroup.tsx
+++ b/packages/ui/src/FormGroup.tsx
@@ -1,10 +1,19 @@
 import React from 'react';
 import { Flex } from '@chakra-ui/react';
 
-export const FormGroup: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => (
-  <Flex direction='column' gap={6} align='start' width='100%' maxWidth={320}>
+interface Props {
+  children: React.ReactNode;
+  maxWidth?: number;
+}
+
+export const FormGroup: React.FC<Props> = ({ children, maxWidth = 320 }) => (
+  <Flex
+    direction='column'
+    gap={6}
+    align='start'
+    width='100%'
+    maxWidth={maxWidth}
+  >
     {children}
   </Flex>
 );

--- a/packages/utils/src/i18n.tsx
+++ b/packages/utils/src/i18n.tsx
@@ -1,7 +1,7 @@
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
-export { useTranslation } from 'react-i18next';
+export { useTranslation, Trans } from 'react-i18next';
 
 type Language = { key: string; description: string; translation: object };
 


### PR DESCRIPTION
Closes #183

### What This Does

* Adds configuration form field to specify fields for `meta`
  * Only visible to leader
  * By default always shows disabled `federation_name` that matches the federation name field
  * Will show meta fields from `FM_EXTRA_DKG_META`, but they will be editable
* Adds list of custom meta during follower confirmation step
  * Doesn't show `federation_name` since it's shown separate as `Federation name`

Note that this does **not** add anything to show you your running federation's meta fields, that will be handled by #184.

## Screenshots

### Leader configuration

<img width="400" alt="CleanShot 2023-10-27 at 11 51 36@2x" src="https://github.com/fedimint/ui/assets/649992/9b0d2bf1-4fe1-447b-ac10-bb487b6b85fa">

### Follower confirmation

<img width="500" alt="CleanShot 2023-10-27 at 22 50 54@2x" src="https://github.com/fedimint/ui/assets/649992/b10303ec-c7ef-4d97-b13d-d7ef3afc1059">