### PR TITLE
fix: gateway explorer links

### DIFF
--- a/apps/gateway-ui/src/App.tsx
+++ b/apps/gateway-ui/src/App.tsx
@@ -136,6 +136,7 @@ export const App = React.memo(function Admin(): JSX.Element {
               <FederationCard
                 key={federation.federation_id}
                 federation={federation}
+                network={gatewayInfo.network}
               />
             );
           })}

--- a/apps/gateway-ui/src/components/DepositCard.tsx
+++ b/apps/gateway-ui/src/components/DepositCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Text,
   Flex,
@@ -14,13 +14,16 @@ import { useTranslation } from '@fedimint/utils';
 import { GatewayCard } from './GatewayCard';
 import { ReactComponent as CopyIcon } from '../assets/svgs/copy.svg';
 import { ReactComponent as LinkIcon } from '../assets/svgs/linkIcon.svg';
+import { Network } from '../types';
 
 export interface DepositCardProps {
   federationId: string;
+  network?: Network;
 }
 
 export const DepositCard = React.memo(function DepositCard({
   federationId,
+  network,
 }: DepositCardProps): JSX.Element {
   const { t } = useTranslation();
   const { gateway } = React.useContext(ApiContext);
@@ -42,6 +45,11 @@ export const DepositCard = React.memo(function DepositCard({
           setError(message);
         });
   }, [address, federationId, gateway]);
+
+  const url = useMemo(
+    () => getAddressUrl(address, network),
+    [address, network]
+  );
 
   return (
     <GatewayCard
@@ -110,7 +118,7 @@ export const DepositCard = React.memo(function DepositCard({
           fontFamily={theme.fonts.body}
           _hover={{ textDecoration: 'underline' }}
           transition={`text-decoration 1s ease-in-out`}
-          href={`https://mempool.space/address/${address}`}
+          href={url.toString()}
           target='_blank'
           rel='noreferrer'
           w='fit-content'
@@ -122,3 +130,18 @@ export const DepositCard = React.memo(function DepositCard({
     </GatewayCard>
   );
 });
+
+const getAddressUrl = (
+  address: string,
+  network: Network = Network.Bitcoin
+): URL => {
+  switch (network) {
+    case Network.Signet:
+      return new URL(`https://mutinynet.com/address/${address}`);
+    case Network.Testnet:
+      return new URL(`https://mempool.space/testnet/address/${address}`);
+    case Network.Bitcoin:
+    case Network.Regtest:
+      return new URL(`https://mempool.space/address/${address}`);
+  }
+};

--- a/apps/gateway-ui/src/components/DepositCard.tsx
+++ b/apps/gateway-ui/src/components/DepositCard.tsx
@@ -123,7 +123,7 @@ export const DepositCard = React.memo(function DepositCard({
           rel='noreferrer'
           w='fit-content'
         >
-          {t('deposit-card.mempool_deposit_link_text')}
+          {t('federation-card.view-link-on', { host: url.host })}
         </Link>
         <LinkIcon color={theme.colors.blue[600]} />
       </Flex>

--- a/apps/gateway-ui/src/components/FederationCard.tsx
+++ b/apps/gateway-ui/src/components/FederationCard.tsx
@@ -32,7 +32,7 @@ export const FederationCard: React.FC<FederationCardProps> = ({
         </Heading>
         <Flex gap='24px' flexDir={{ base: 'column', sm: 'column', md: 'row' }}>
           <BalanceCard balance_msat={balance_msat} />
-          <InfoCard nodeId={federation_id} nodeLink={federation_id} />
+          <InfoCard nodeId={federation_id} network={network} />
         </Flex>
         <Flex gap='24px' flexDir={{ base: 'column', sm: 'column', md: 'row' }}>
           <DepositCard federationId={federation_id} network={network} />

--- a/apps/gateway-ui/src/components/FederationCard.tsx
+++ b/apps/gateway-ui/src/components/FederationCard.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import { Flex, Stack, useTheme, Heading } from '@chakra-ui/react';
-import { Federation } from '../types';
+import { Federation, Network } from '../types';
 import { InfoCard, DepositCard, BalanceCard, WithdrawCard } from '.';
 import { useTranslation } from '@fedimint/utils';
 
 interface FederationCardProps {
   federation: Federation;
+  network?: Network;
 }
 
-export const FederationCard: React.FC<FederationCardProps> = (props) => {
-  const { federation_id, balance_msat, config } = props.federation;
+export const FederationCard: React.FC<FederationCardProps> = ({
+  federation,
+  network,
+}) => {
+  const { federation_id, balance_msat, config } = federation;
   const theme = useTheme();
   const { t } = useTranslation();
 
@@ -31,7 +35,7 @@ export const FederationCard: React.FC<FederationCardProps> = (props) => {
           <InfoCard nodeId={federation_id} nodeLink={federation_id} />
         </Flex>
         <Flex gap='24px' flexDir={{ base: 'column', sm: 'column', md: 'row' }}>
-          <DepositCard federationId={federation_id} />
+          <DepositCard federationId={federation_id} network={network} />
           <WithdrawCard
             federationId={federation_id}
             balanceMsat={balance_msat}

--- a/apps/gateway-ui/src/components/InfoCard.tsx
+++ b/apps/gateway-ui/src/components/InfoCard.tsx
@@ -11,19 +11,21 @@ import { formatEllipsized, useTranslation } from '@fedimint/utils';
 import { GatewayCard } from '.';
 import { ReactComponent as CopyIcon } from '../assets/svgs/copy.svg';
 import { ReactComponent as LinkIcon } from '../assets/svgs/linkIcon.svg';
+import { Network } from '../types';
 
 interface InfoCardProps {
   nodeId: string;
-  nodeLink: string;
+  network?: Network;
 }
 
-export const InfoCard = React.memo(function InfoCard(
-  props: InfoCardProps
-): JSX.Element {
+export const InfoCard = React.memo(function InfoCard({
+  nodeId,
+  network,
+}: InfoCardProps): JSX.Element {
   const { t } = useTranslation();
-  const { nodeId, nodeLink } = props;
   const theme = useTheme();
   const { onCopy, hasCopied } = useClipboard(nodeId);
+  const url = getNodeUrl(nodeId, network);
 
   return (
     <GatewayCard title={t('info-card.card_header')}>
@@ -72,7 +74,7 @@ export const InfoCard = React.memo(function InfoCard(
           fontFamily={theme.fonts.body}
           _hover={{ textDecoration: 'underline' }}
           transition={`text-decoration 1s ease-in-out`}
-          href={`https://amboss.space/node/${nodeLink}`}
+          href={url.toString()}
           target='_blank'
           rel='noreferrer'
           w='fit-content'
@@ -84,3 +86,18 @@ export const InfoCard = React.memo(function InfoCard(
     </GatewayCard>
   );
 });
+
+const getNodeUrl = (
+  nodeId: string,
+  network: Network = Network.Bitcoin
+): URL => {
+  switch (network) {
+    case Network.Signet:
+      return new URL(`https://mutinynet.com/lightning/node/${nodeId}`);
+    case Network.Testnet:
+      return new URL(`https://mempool.space/testnet/lightning/node/${nodeId}`);
+    case Network.Bitcoin:
+    case Network.Regtest:
+      return new URL(`https://mempool.space/lightning/node/${nodeId}`);
+  }
+};

--- a/apps/gateway-ui/src/components/InfoCard.tsx
+++ b/apps/gateway-ui/src/components/InfoCard.tsx
@@ -79,7 +79,7 @@ export const InfoCard = React.memo(function InfoCard({
           rel='noreferrer'
           w='fit-content'
         >
-          {t('info-card.amboss_node_link_text')}
+          {t('federation-card.view-link-on', { host: url.host })}
         </Link>
         <LinkIcon color={theme.colors.blue[600]} />
       </Flex>

--- a/apps/gateway-ui/src/languages/en.json
+++ b/apps/gateway-ui/src/languages/en.json
@@ -37,14 +37,14 @@
     "card_header": "Deposit Bitcoin",
     "confirmations": "Confirmations:",
     "header": "Bitcoin Deposit to Federation",
-    "mempool_deposit_link_text": "View on mempool.space",
     "receiving-address": "Receiving Addr",
     "required": "required",
     "sentence-one": "Deposit to the address or scan the QR code",
     "transaction-id": "Transaction ID"
   },
   "federation-card": {
-    "default-federation-name": "Your federation"
+    "default-federation-name": "Your federation",
+    "view-link-on": "View on {{host}}"
   },
   "footer": {
     "blog-link-text": "Blog",
@@ -69,7 +69,6 @@
     "sort": "Sort"
   },
   "info-card": {
-    "amboss_node_link_text": "View on amboss.space",
     "card_header": "Node ID"
   },
   "withdraw-card": {

--- a/apps/gateway-ui/src/languages/es.json
+++ b/apps/gateway-ui/src/languages/es.json
@@ -31,7 +31,6 @@
     "card_header": "Depositar Bitcoins",
     "confirmations": "Confirmaciones:",
     "header": "Depósito de Bitcoin a la Federación",
-    "mempool_deposit_link_text": "Ver en mempool.space",
     "receiving-address": "Dirección de recepción",
     "required": "requerido",
     "sentence-one": "Deposita a la dirección o escanea el código QR",
@@ -63,7 +62,6 @@
     "sort": "Ordenar"
   },
   "info-card": {
-    "amboss_node_link_text": "Ver en amboss.space",
     "card_header": "ID de nodo"
   },
   "withdraw-card": {

--- a/apps/gateway-ui/src/languages/ko.json
+++ b/apps/gateway-ui/src/languages/ko.json
@@ -31,7 +31,6 @@
     "card_header": "비트코인 입금",
     "confirmations": "확인:",
     "header": "페더레이션에 비트코인 예금",
-    "mempool_deposit_link_text": "mempool.space에서 보기",
     "receiving-address": "수신주소",
     "required": "필수의",
     "sentence-one": "해당 주소로 입금하거나 QR코드를 스캔하세요.",
@@ -63,7 +62,6 @@
     "sort": "정렬"
   },
   "info-card": {
-    "amboss_node_link_text": "amboss.space에서 보기",
     "card_header": "노드 ID"
   },
   "withdraw-card": {

--- a/apps/gateway-ui/src/types.tsx
+++ b/apps/gateway-ui/src/types.tsx
@@ -43,6 +43,15 @@ export interface GatewayInfo {
   lightning_alias: string;
   lightning_pub_key: string;
   version_hash: string;
+  network?: Network;
+}
+
+// Type adaptation from https://docs.rs/bitcoin/latest/bitcoin/network/enum.Network.html
+export enum Network {
+  Bitcoin = 'main',
+  Testnet = 'test',
+  Signet = 'signet',
+  Regtest = 'regtest',
 }
 
 export type TransactionId = string;


### PR DESCRIPTION
When gateway is deployed on mainnet and testnet, gateway address and node links should point to valid mempool.space links.
On signet, we assume gateway is deployed on mutinynet.com where we point both links. When gateway is on regtest, or the network is not yet known, we don't show "view in explorer" links

Changes in gateway UI take effect after https://github.com/fedimint/fedimint/pull/3455 which introduces `network` field to gateway info. To validate these changes before the upstream changes modify the `network` prop in `FederationCard` and  observe how the links are affected. Valid network values are `"main" | "test" | "signet" | "regtest"`

closes #242 