### PR TITLE
feat: confirm password field

### DIFF
--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -51,6 +51,8 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
   const isHost = role === GuardianRole.Host;
   const [myName, setMyName] = useState(stateMyName);
   const [password, setPassword] = useState(statePassword);
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordsMatch, setPasswordsMatch] = useState(false);
   const [hostServerUrl, setHostServerUrl] = useState('');
   const [defaultParams, setDefaultParams] = useState<ConfigGenParams>();
   const [numPeers, setNumPeers] = useState(
@@ -121,6 +123,10 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
           network
       )
     : Boolean(myName && password && hostServerUrl);
+
+  useEffect(() => {
+    setPasswordsMatch(password === confirmPassword);
+  }, [password, confirmPassword]);
 
   const handleChangeFederationName = (
     ev: React.ChangeEvent<HTMLInputElement>
@@ -214,6 +220,19 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
             isDisabled={!!statePassword}
           />
           <FormHelperText>{t('set-config.admin-password-help')}</FormHelperText>
+        </FormControl>
+        <FormControl>
+          <FormLabel>{t('set-config.confirm-password')}</FormLabel>
+          <Input
+            type='password'
+            value={confirmPassword}
+            onChange={(ev) => setConfirmPassword(ev.currentTarget.value)}
+          />
+          <FormHelperText>
+            {passwordsMatch && password.length > 0
+              ? 'Passwords match!'
+              : 'Passwords do not match!'}
+          </FormHelperText>
         </FormControl>
         {!isHost && (
           <FormControl>
@@ -318,8 +337,8 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
       )}
       <div>
         <Button
-          isDisabled={!isValid}
-          onClick={isValid ? handleNext : undefined}
+          isDisabled={!isValid || !passwordsMatch}
+          onClick={isValid && passwordsMatch ? handleNext : undefined}
           leftIcon={<Icon as={ArrowRightIcon} />}
           mt={4}
         >

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Text,
   useTheme,
+  FormErrorMessage,
 } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
 import { FormGroup, FormGroupHeading } from '@fedimint/ui';
@@ -52,7 +53,6 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
   const [myName, setMyName] = useState(stateMyName);
   const [password, setPassword] = useState(statePassword);
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [passwordsMatch, setPasswordsMatch] = useState(false);
   const [hostServerUrl, setHostServerUrl] = useState('');
   const [defaultParams, setDefaultParams] = useState<ConfigGenParams>();
   const [numPeers, setNumPeers] = useState(
@@ -116,6 +116,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
     ? Boolean(
         myName &&
           password &&
+          password === confirmPassword &&
           federationName &&
           isValidNumber(numPeers, 4) &&
           isValidNumber(blockConfirmations, 1, 200) &&
@@ -123,10 +124,6 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
           network
       )
     : Boolean(myName && password && hostServerUrl);
-
-  useEffect(() => {
-    setPasswordsMatch(password === confirmPassword);
-  }, [password, confirmPassword]);
 
   const handleChangeFederationName = (
     ev: React.ChangeEvent<HTMLInputElement>
@@ -221,18 +218,20 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
           />
           <FormHelperText>{t('set-config.admin-password-help')}</FormHelperText>
         </FormControl>
-        <FormControl>
+        <FormControl
+          isInvalid={password !== confirmPassword && password.length > 0}
+        >
           <FormLabel>{t('set-config.confirm-password')}</FormLabel>
           <Input
             type='password'
             value={confirmPassword}
             onChange={(ev) => setConfirmPassword(ev.currentTarget.value)}
           />
-          <FormHelperText>
-            {passwordsMatch && password.length > 0
-              ? 'Passwords match!'
-              : 'Passwords do not match!'}
-          </FormHelperText>
+          <FormErrorMessage>
+            {password !== confirmPassword &&
+              password.length > 0 &&
+              t('set-config.error-password-mismatch')}
+          </FormErrorMessage>
         </FormControl>
         {!isHost && (
           <FormControl>
@@ -337,8 +336,8 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
       )}
       <div>
         <Button
-          isDisabled={!isValid || !passwordsMatch}
-          onClick={isValid && passwordsMatch ? handleNext : undefined}
+          isDisabled={!isValid}
+          onClick={isValid ? handleNext : undefined}
           leftIcon={<Icon as={ArrowRightIcon} />}
           mt={4}
         >

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -85,6 +85,7 @@
     "admin-password-help": "You'll need this every time you visit this page.",
     "confirm-password": "Confirm password",
     "confirm-password-help": "You'll need this every time you visit this page.",
+    "error-password-mismatch": "Passwords don't match",
     "join-federation": "Join Federation link",
     "join-federation-help": "Ask the person who created the Federation for a link, and paste it here.",
     "federation-settings": "Federation settings",

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -83,6 +83,8 @@
     "guardian-name-help": "This name will be shown to other Guardians",
     "admin-password": "Admin password",
     "admin-password-help": "You'll need this every time you visit this page.",
+    "confirm-password": "Confirm password",
+    "confirm-password-help": "You'll need this every time you visit this page.",
     "join-federation": "Join Federation link",
     "join-federation-help": "Ask the person who created the Federation for a link, and paste it here.",
     "federation-settings": "Federation settings",
@@ -100,7 +102,7 @@
     "error-valid-max": "Please input a number of at most {{max}}.",
     "error-valid-min-max": "Please input a number between {{min}} and {{max}}.",
     "meta-fields": "Meta fields",
-    "meta-fields-description": "Additional configuration sent to fedimint clients. See <docs>documentation</docs> or more information.",
+    "meta-fields-description": "Additional configuration sent to fedimint clients. See <docs>documentation</docs> for more information.",
     "meta-fields-key": "Meta key",
     "meta-fields-value": "Value",
     "meta-fields-add-another": "Add another"

--- a/apps/guardian-ui/src/languages/es.json
+++ b/apps/guardian-ui/src/languages/es.json
@@ -90,6 +90,9 @@
   "set-config": {
     "admin-password": "Contraseña de administrador",
     "admin-password-help": "Necesitarás esto cada vez que visites esta página.",
+    "confirm-password": "Confirmar contraseña",
+    "confirm-password-help": "Necesitarás esto cada vez que visites esta página",
+    "error-password-mismatch": "Las contraseñas no coinciden",
     "bitcoin-network": "Red de Bitcoin",
     "bitcoin-rpc": "RPC de Bitcoin",
     "block-confirmations": "Confirmaciones de bloque",

--- a/apps/guardian-ui/src/languages/ko.json
+++ b/apps/guardian-ui/src/languages/ko.json
@@ -90,6 +90,9 @@
   "set-config": {
     "admin-password": "관리자 비밀번호",
     "admin-password-help": "매번 페이지를 방문할 때마다 필요합니다.",
+    "confirm-password": "비밀번호 확인",
+    "confirm-password-help": "이 페이지를 방문할 때마다 이 정보가 필요합니다.",
+    "error-password-mismatch": "비밀번호가 일치하지 않습니다",
     "bitcoin-network": "비트코인 네트워크",
     "bitcoin-rpc": "비트코인 RPC",
     "block-confirmations": "블록 확인",


### PR DESCRIPTION
Adds a "Confirm password" field, might also want to put the "click to view password" options.

Had an issue with a federation setup today: 1 guardian forgot their password after clicking away rom the "verification codes" section of federation setup. this meant that the guardian couldn't continue setup and all the other guardians were already in a state waiting for that specific guardian and couldn't do a hard reset, which bricked the entire federation.

@wbobeirne @sethwynne plz fix so it looks nice and fits UI scheme but until fedimint allows for hard reset having this as a backstop will be useful.