### PR TITLE
Add guardian ui to `nix-gateway`, fix scripts not exiting

### DIFF
--- a/mprocs-nix-gateway.yml
+++ b/mprocs-nix-gateway.yml
@@ -24,6 +24,13 @@ procs:
     shell: tail -n +0 -F $FM_LOGS_DIR/devimint.log
   gateway-ui:
     shell: bash --init-file scripts/mprocs-nix-gateway.sh
+    stop: SIGKILL
     env:
       PORT: '3004'
+      BROWSER: none
+  guardian-ui:
+    shell: bash --init-file scripts/mprocs-nix-guardian.sh
+    stop: SIGKILL
+    env:
+      PORT: '3000'
       BROWSER: none

--- a/scripts/mprocs-nix-guardian.sh
+++ b/scripts/mprocs-nix-guardian.sh
@@ -15,7 +15,7 @@ then
 fi
 
 # Conigure UI env from devimint env
-export REACT_APP_FM_GATEWAY_API=$FM_GATEWAY_API_ADDR
-export REACT_APP_FM_GATEWAY_PASSWORD=$FM_GATEWAY_PASSWORD
+CONFIG_PORT=$(($FM_PORT_FEDIMINTD_BASE + 1)) # Fedimintd 0 config AOU port is always base + 1
+export REACT_APP_FM_CONFIG_API="ws://127.0.0.1:$CONFIG_PORT"
 
-yarn dev:gateway-ui
+yarn dev:guardian-ui


### PR DESCRIPTION
Closes #262, closes #261

* Add `set -eo pipefail` to mprocs scripts
* Add `stop: SIGKILL` to mprocs bash scripts
* Add `mprocs-nix-guardian.sh` script for `mprocs-nix-gateway.yml` to run a guardian UI