### PR TITLE
guardian-ui: fix config verification

### DIFF
--- a/apps/guardian-ui/src/setup/SetupContext.tsx
+++ b/apps/guardian-ui/src/setup/SetupContext.tsx
@@ -16,6 +16,7 @@ import {
   ServerStatus,
 } from '../types';
 import { GuardianApi } from '../GuardianApi';
+import { isConsensusparams } from '../utils/validators';
 
 const LOCAL_STORAGE_SETUP_KEY = 'setup-guardian-ui-state';
 
@@ -35,7 +36,7 @@ function makeInitialState(loadFromStorage = true): SetupState {
     }
   }
 
-  return {
+  const initialState = {
     role: null,
     progress: SetupProgress.Start,
     myName: '',
@@ -46,6 +47,18 @@ function makeInitialState(loadFromStorage = true): SetupState {
     ourCurrentId: null,
     ...storageState,
   };
+
+  if (
+    initialState.progress !== SetupProgress.Start &&
+    initialState.configGenParams !== null &&
+    isConsensusparams(initialState.configGenParams)
+  ) {
+    const peers = Object.values(initialState.configGenParams.peers);
+    initialState.peers = peers;
+    initialState.numPeers = peers.length;
+  }
+
+  return initialState;
 }
 
 const initialState = makeInitialState();
@@ -183,6 +196,7 @@ export const SetupContextProvider: React.FC<SetupContextProviderProps> = ({
         myName: state.myName,
         numPeers: state.numPeers,
         configGenParams: state.configGenParams,
+        ourCurrentId: state.ourCurrentId,
       })
     );
 
@@ -199,6 +213,7 @@ export const SetupContextProvider: React.FC<SetupContextProviderProps> = ({
     state.myName,
     state.numPeers,
     state.configGenParams,
+    state.ourCurrentId,
   ]);
 
   // Fetch consensus state, dispatch updates with it.

--- a/apps/guardian-ui/src/types/setup.ts
+++ b/apps/guardian-ui/src/types/setup.ts
@@ -64,7 +64,7 @@ export type ConfigGenParams = {
   modules: Record<number, AnyModuleParams>;
 };
 
-type ConsensusParams = ConfigGenParams & {
+export type ConsensusParams = ConfigGenParams & {
   peers: Record<number, Peer>;
 };
 

--- a/apps/guardian-ui/src/utils/validators.ts
+++ b/apps/guardian-ui/src/utils/validators.ts
@@ -1,3 +1,5 @@
+import { ConfigGenParams, ConsensusParams } from '../types';
+
 export const isValidNumber = (value: string, min?: number, max?: number) => {
   const int = parseInt(value, 10);
   if (Number.isNaN(int)) return false;
@@ -9,3 +11,9 @@ export const isValidNumber = (value: string, min?: number, max?: number) => {
 export const isValidMeta = (meta: [string, string][]) => {
   return meta.every(([key, value]) => key && value);
 };
+
+export function isConsensusparams(
+  params: ConfigGenParams | ConsensusParams
+): params is ConsensusParams {
+  return 'peers' in params;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   fedimintd_1:
     # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
-    image: fedimint/fedimintd:23ee7cb6e96fce89bb024fbc1fcfccbfb3dc968b
+    image: fedimint/fedimintd:f58f1913e62b6529a2ff36ec5c89a3852aba7ca7
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18173
@@ -21,7 +21,7 @@ services:
 
   gatewayd_1:
     # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
-    image: fedimint/gatewayd:23ee7cb6e96fce89bb024fbc1fcfccbfb3dc968b
+    image: fedimint/gatewayd:f58f1913e62b6529a2ff36ec5c89a3852aba7ca7
     command: gatewayd lnd
     environment:
       # Path to folder containing gateway config and data files
@@ -61,7 +61,7 @@ services:
 
   fedimintd_2:
     # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
-    image: fedimint/fedimintd:23ee7cb6e96fce89bb024fbc1fcfccbfb3dc968b
+    image: fedimint/fedimintd:f58f1913e62b6529a2ff36ec5c89a3852aba7ca7
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18173
@@ -85,7 +85,7 @@ services:
 
   fedimintd_3:
     # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
-    image: fedimint/fedimintd:23ee7cb6e96fce89bb024fbc1fcfccbfb3dc968b
+    image: fedimint/fedimintd:f58f1913e62b6529a2ff36ec5c89a3852aba7ca7
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18174
@@ -103,7 +103,7 @@ services:
 
   fedimintd_4:
     # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
-    image: fedimint/fedimintd:23ee7cb6e96fce89bb024fbc1fcfccbfb3dc968b
+    image: fedimint/fedimintd:f58f1913e62b6529a2ff36ec5c89a3852aba7ca7
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18175

--- a/flake.lock
+++ b/flake.lock
@@ -101,17 +101,17 @@
         "nixpkgs-unstable": "nixpkgs-unstable_2"
       },
       "locked": {
-        "lastModified": 1699286165,
-        "narHash": "sha256-xsZPbT1GgFZRT1K5hsmDTP7TQJ6qNKtMcglWwa+43LA=",
+        "lastModified": 1699573846,
+        "narHash": "sha256-4xKNhUE7e3GjjMbNib35B7eJWjuDIbYtwoHBOWYtqFA=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "23ee7cb6e96fce89bb024fbc1fcfccbfb3dc968b",
+        "rev": "f58f1913e62b6529a2ff36ec5c89a3852aba7ca7",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "23ee7cb6e96fce89bb024fbc1fcfccbfb3dc968b",
+        "rev": "f58f1913e62b6529a2ff36ec5c89a3852aba7ca7",
         "type": "github"
       }
     },
@@ -232,11 +232,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -336,11 +336,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1692025715,
-        "narHash": "sha256-tsRiiopGT7HA8d/cuk5xYBRXgdnnvD+JhUGUe3x7vmY=",
+        "lastModified": 1697226376,
+        "narHash": "sha256-cumLLb1QOUtWieUnLGqo+ylNt3+fU8Lcv5Zl+tYbRUE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09a137528c3aea3780720d19f99cd706f52c3823",
+        "rev": "898cb2064b6e98b8c5499f37e81adbdf2925f7c5",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1693183237,
-        "narHash": "sha256-c7OtyBkZ/vZE/WosBpRGRtkbWZjDHGJP7fg1FyB9Dsc=",
+        "lastModified": 1699596684,
+        "narHash": "sha256-XSXP8zjBZJBVvpNb2WmY0eW8O2ce+sVyj1T0/iBRIvg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea5234e7073d5f44728c499192544a84244bf35a",
+        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      url = "github:fedimint/fedimint?rev=23ee7cb6e96fce89bb024fbc1fcfccbfb3dc968b";
+      url = "github:fedimint/fedimint?rev=f58f1913e62b6529a2ff36ec5c89a3852aba7ca7";
     };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:


### PR DESCRIPTION
At the config verification step after all the guardians have verified other configs, if the leader continued their own setup to completion before the follower guardians, there is a chance the followers would not be able to **resume and complete** their setup since we relied on their servers being able to continuously poll the leader's server for consensus configuration.

This PR fixes the bug, allowing all guardians to complete federation set-up in any order, provided they have successfully coordinated through config verification.

## Steps to validate

1. Before fix:
- Follow federation set-up through config verification until you see "All guardians have verified their codes"
- Reload any guardians setup page to confirm that the verified codes are automatically pre-filled on reload
- Complete set-up for the leader
- Reload the page for any other guardian and observe that config verification shows an error. The verification page expects the leader's server to still be in set up and not in consensus running

2. After fix:
- Follow federation set-up through config verification until you see "All guardians have verified their codes"
- Reload any guardians setup page to observe that the verified codes are automatically pre-filled on reload
- Complete set-up for the leader
- Reload the page for any other guardian and observe that the verified codes are automatically pre-filled on reload
- Confirm you can complete set-up for these "follower" guardians

Fixes #255 