### PR TITLE
Guardian-ui README.MD now shows how to startup four guardian instances to meet minimum guardian requirement

### DIFF
--- a/apps/guardian-ui/README.md
+++ b/apps/guardian-ui/README.md
@@ -27,7 +27,19 @@ Do the following in separate terminals:
 
 1. Confirm you are in `guardian-ui/` directory
 1. Run `PORT=3001 REACT_APP_FM_CONFIG_API="ws://127.0.0.1:18184" yarn dev`
-   - This will be your "Follower" instance
+   - This will be your first "Follower" instance
+
+- **Third Terminal**
+
+1. Confirm you are in `guardian-ui/` directory
+1. Run `PORT=3002 REACT_APP_FM_CONFIG_API="ws://127.0.0.1:18185" yarn dev`
+   - This will be your second "Follower" instance
+  
+- **Fourth Terminal** 
+
+1. Confirm you are in `guardian-ui/` directory
+1. Run `PORT=3003 REACT_APP_FM_CONFIG_API="ws://127.0.0.1:18186" yarn dev`
+   - This will be your third "Follower" instance
 
 ### Set up your federation
 


### PR DESCRIPTION
This was a quick change to add two additional guardian instances to work with the docker compose configured back-end. Plus a smoketest of the PR process for the project ;)