### PR TITLE
fix: status-fix typo

### DIFF
--- a/apps/guardian-ui/src/components/GuardiansCard.tsx
+++ b/apps/guardian-ui/src/components/GuardiansCard.tsx
@@ -22,7 +22,7 @@ export const GuardiansCard: React.FC<Props> = ({ status, config }) => {
       },
       {
         key: 'status',
-        heading: t('federation-dashboard.guardians.name-label'),
+        heading: t('federation-dashboard.guardians.status-label'),
       },
       {
         key: 'health',


### PR DESCRIPTION
@Kodylow helped me set up the ui repos yesterday and I saw a small error with the status label for the guardian UI.