### PR TITLE
nix develop shellHook for yarn install and starship

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,14 @@
               pkgs.mprocs
               pkgs.nodejs
               pkgs.yarn
+              pkgs.starship
               fedimint.packages.${system}.devimint
               fedimint.packages.${system}.gateway-pkgs
               fedimint.packages.${system}.fedimint-pkgs
             ] ++ prev.nativeBuildInputs;
             shellHook = ''
               yarn install
+              eval "$(starship init bash)"
             '';
           });
         };

--- a/flake.nix
+++ b/flake.nix
@@ -21,14 +21,12 @@
               pkgs.mprocs
               pkgs.nodejs
               pkgs.yarn
-              pkgs.starship
               fedimint.packages.${system}.devimint
               fedimint.packages.${system}.gateway-pkgs
               fedimint.packages.${system}.fedimint-pkgs
             ] ++ prev.nativeBuildInputs;
             shellHook = ''
               yarn install
-              eval "$(starship init bash)"
             '';
           });
         };

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
       url = "github:fedimint/fedimint?rev=23ee7cb6e96fce89bb024fbc1fcfccbfb3dc968b";
     };
   };
@@ -26,6 +25,9 @@
               fedimint.packages.${system}.gateway-pkgs
               fedimint.packages.${system}.fedimint-pkgs
             ] ++ prev.nativeBuildInputs;
+            shellHook = ''
+              yarn install
+            '';
           });
         };
       });


### PR DESCRIPTION
adds yarn install check when entering `nix develop` and starship to shell, turbo bin gets installed by yarn install instead of nix.