### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Replace `-p 3001:3000` with a port of your choice, `REACT_APP_FM_GATEWAY_API` wi
 
 ## Development
 
-### Option 1 - Using Nix (preferred)
+### Option 1 - Running with Nix (preferred)
 
 1. Install Nix
    ```bash
@@ -131,7 +131,7 @@ nix-guardian spins up these instances
 | guardian-ui-3 | http://127.0.0.1:3002/ |
 | guardian-ui-4 | http://127.0.0.1:3003/ |
 
-### Option 2 - Using Docker Compose and Yarn manually
+### Option 2 - Running with Docker Compose and Yarn manually
 
 From root repo directory:
 
@@ -154,7 +154,7 @@ From root repo directory:
 
 After running through the config setup UI flow once, you will need to delete the `fedimintd` data to run through it again. To do this, delete the `fm_1`, `fm_2`, `fm_3`, and `fm_4` folder from the repo. These are data directories mounted to Docker containers running fedmintd and are listed in `.gitignore` so are safe to remove.
 
-### Running mprocs
+### Running with mprocs
 
 1. Install [mprocs](https://github.com/pvolok/mprocs)
 1. Run `mprocs -c mprocs.yml`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,43 @@ Fedimint UI releases use semantic versioning (`major.minor.patch`)
 
 ## Running a Release
 
+### Running with Nix
+
+1. Install Nix
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   ```
+1. Add `experimental-features = nix-command flakes` to your `/etc/nix/nix.conf` file   
+1. In terminal `cd` to the fedimint-ui repo root directory
+1. Enter the following command to start Nix development environment
+   ```bash
+   nix develop
+   ```
+1. Run `yarn nix-gateway` or `nix-guardian` Note: **nix-gateway** preconfigures the federation so you don't have to go through federation setup. **nix-guardian** starts separate guardian nodes that are connected into the federation when you run through the federation setup process.
+
+**guardian-ui**
+```bash
+yarn nix-guardian
+```
+nix-guardian spins up these instances
+| ui instance | uri |
+| ----------------- | --- |
+| guardian-ui-1 | http://127.0.0.1:3000/ |
+| guardian-ui-2 | http://127.0.0.1:3001/ |
+| guardian-ui-3 | http://127.0.0.1:3002/ |
+| guardian-ui-4 | http://127.0.0.1:3003/ |
+
+**gateway-ui**
+```bash
+yarn nix-gateway
+```
+| ui instance | uri | 
+| ----------------- | --- |
+| gateway-ui | http://127.0.0.1:3004/ |
+| guardian-ui | http://127.0.0.1:3000/ |
+
+
+
 ### Build and Run from Source
 
 #### Guardian UI
@@ -116,13 +153,9 @@ From root repo directory:
 
 After running through the config setup UI flow once, you will need to delete the `fedimintd` data to run through it again. To do this, delete the `fm_1`, `fm_2`, `fm_3`, and `fm_4` folder from the repo. These are data directories mounted to Docker containers running fedmintd and are listed in `.gitignore` so are safe to remove.
 
-### Running with Nix and mprocs
+### Running mprocs
 
 1. Install [mprocs](https://github.com/pvolok/mprocs)
-1. Install [Nix](https://nixos.org/download)
-1. Add `experimental-features = nix-command flakes` to your `/etc/nix/nix.conf` file
-1. In a terminal `cd` to the fedimint-ui repo root directory
-1. Run `nix develop`
 1. Run `mprocs -c mprocs.yml`
 
 After running this command, you'll be present with the mprocs display. Along the left side are the list of processes currently available by mprocs. Along the bottom are hotkeys for navigating/interacting with mprocs. The main pane shows the shell output for the currently selected process.
@@ -134,14 +167,6 @@ The `stop-servers` process can be used to stop all docker containers by hitting 
 The `guardian-ui-1`, `guardian-ui-2`, `guardian-ui-3`, `guardian-ui-4` are instances of `guardian-ui` apps, each running on different ports and connected to a unique `fedimintd` server instance (running in the `start-servers` process).
 
 The `gateway-ui` is an instance of `gateway-ui` app, connected to a `gatewayd` server instance (running in the `start-servers` process).
-
-| ui instance | uri | api endpoint
-| ----------------- | --- | -------------------------- |
-| guardian-ui-1 | http://127.0.0.1:3000/ | ws://127.0.0.1:18174 |
-| guardian-ui-2 | http://127.0.0.1:3001/ | ws://127.0.0.1:18184 |
-| guardian-ui-3 | http://127.0.0.1:3002/ | ws://127.0.0.1:18185 |
-| guardian-ui-4 | http://127.0.0.1:3003/ | ws://127.0.0.1:18186 |
-| gateway-ui | http://127.0.0.1:3004/ | http://127.0.0.1:8175 |
 
 You can see more details by viewing the `mprocs.yml` file.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Fedimint UI releases use semantic versioning (`major.minor.patch`)
 
 ## Running a Release
 
-### Running with Nix
+### Option 1 - Running with Nix (preferred)
 
 1. Install Nix
    ```bash
@@ -50,7 +50,17 @@ Fedimint UI releases use semantic versioning (`major.minor.patch`)
    ```
 1. Run `yarn nix-gateway` or `yarn nix-guardian` Note: **nix-gateway** preconfigures the federation so you don't have to go through federation setup. **nix-guardian** starts separate guardian nodes that are connected into the federation when you run through the federation setup process.
 
-**guardian-ui**
+#### **Gateway UI**
+```bash
+yarn nix-gateway
+```
+nix-gateway spins up these instances
+| instance | url | 
+| ---------- | --- |
+| gateway-ui | http://127.0.0.1:3004/ |
+| guardian-ui | http://127.0.0.1:3000/ |
+
+#### **Guardian UI**
 ```bash
 yarn nix-guardian
 ```
@@ -62,19 +72,8 @@ nix-guardian spins up these instances
 | guardian-ui-3 | http://127.0.0.1:3002/ |
 | guardian-ui-4 | http://127.0.0.1:3003/ |
 
-**gateway-ui**
-```bash
-yarn nix-gateway
-```
-nix-gateway spins up these instances
-| instance | url | 
-| ---------- | --- |
-| gateway-ui | http://127.0.0.1:3004/ |
-| guardian-ui | http://127.0.0.1:3000/ |
 
-
-
-### Build and Run from Source
+### Option 2 - Build and Run from Source
 
 #### Guardian UI
 
@@ -96,7 +95,7 @@ yarn install
 PORT=3001 REACT_APP_FM_GATEWAY_API="http://127.0.0.1:8175" REACT_APP_FM_GATEWAY_PASSWORD="yourpassword" yarn build && yarn start
 ```
 
-### Run with Docker
+### Option 3 - Run with Docker
 
 **Note:** Docker images are only built for `linux/amd64`. Your docker will need to support virtualization to run on other platforms.
 

--- a/README.md
+++ b/README.md
@@ -36,44 +36,7 @@ Fedimint UI releases use semantic versioning (`major.minor.patch`)
 
 ## Running a Release
 
-### Option 1 - Running with Nix (preferred)
-
-1. Install Nix
-   ```bash
-   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
-   ```
-1. Add `experimental-features = nix-command flakes` to your `/etc/nix/nix.conf` file   
-1. In terminal `cd` to the fedimint-ui repo root directory
-1. Enter the following command to start Nix development environment
-   ```bash
-   nix develop
-   ```
-1. Run `yarn nix-gateway` or `yarn nix-guardian` Note: **nix-gateway** preconfigures the federation so you don't have to go through federation setup. **nix-guardian** starts separate guardian nodes that are connected into the federation when you run through the federation setup process.
-
-#### **Gateway UI**
-```bash
-yarn nix-gateway
-```
-nix-gateway spins up these instances
-| instance | url | 
-| ---------- | --- |
-| gateway-ui | http://127.0.0.1:3004/ |
-| guardian-ui | http://127.0.0.1:3000/ |
-
-#### **Guardian UI**
-```bash
-yarn nix-guardian
-```
-nix-guardian spins up these instances
-| instance | url |
-| ------------- | --- |
-| guardian-ui-1 | http://127.0.0.1:3000/ |
-| guardian-ui-2 | http://127.0.0.1:3001/ |
-| guardian-ui-3 | http://127.0.0.1:3002/ |
-| guardian-ui-4 | http://127.0.0.1:3003/ |
-
-
-### Option 2 - Build and Run from Source
+### Build and Run from Source
 
 #### Guardian UI
 
@@ -95,7 +58,7 @@ yarn install
 PORT=3001 REACT_APP_FM_GATEWAY_API="http://127.0.0.1:8175" REACT_APP_FM_GATEWAY_PASSWORD="yourpassword" yarn build && yarn start
 ```
 
-### Option 3 - Run with Docker
+### Run with Docker
 
 **Note:** Docker images are only built for `linux/amd64`. Your docker will need to support virtualization to run on other platforms.
 
@@ -131,6 +94,44 @@ docker run \
 Replace `-p 3001:3000` with a port of your choice, `REACT_APP_FM_GATEWAY_API` with the domain and port of your gatewayd API, and REACT_APP_FM_GATEWAY_PASSWORD with the password you set your gateway up with.
 
 ## Development
+
+### Option 1 - Using Nix (preferred)
+
+1. Install Nix
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   ```
+1. Add `experimental-features = nix-command flakes` to your `/etc/nix/nix.conf` file   
+1. In terminal `cd` to the fedimint-ui repo root directory
+1. Enter the following command to start Nix development environment
+   ```bash
+   nix develop
+   ```
+1. Run `yarn nix-gateway` or `yarn nix-guardian` Note: **nix-gateway** preconfigures the federation so you don't have to go through federation setup. **nix-guardian** starts separate guardian nodes that are connected into the federation when you run through the federation setup process.
+
+#### **Gateway UI**
+```bash
+yarn nix-gateway
+```
+nix-gateway spins up these instances
+| instance | url | 
+| ---------- | --- |
+| gateway-ui | http://127.0.0.1:3004/ |
+| guardian-ui | http://127.0.0.1:3000/ |
+
+#### **Guardian UI**
+```bash
+yarn nix-guardian
+```
+nix-guardian spins up these instances
+| instance | url |
+| ------------- | --- |
+| guardian-ui-1 | http://127.0.0.1:3000/ |
+| guardian-ui-2 | http://127.0.0.1:3001/ |
+| guardian-ui-3 | http://127.0.0.1:3002/ |
+| guardian-ui-4 | http://127.0.0.1:3003/ |
+
+### Option 2 - Using Docker Compose and Yarn manually
 
 From root repo directory:
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Fedimint UI releases use semantic versioning (`major.minor.patch`)
 yarn nix-guardian
 ```
 nix-guardian spins up these instances
-| ui instance | url |
-| ----------------- | --- |
+| instance | url |
+| ------------- | --- |
 | guardian-ui-1 | http://127.0.0.1:3000/ |
 | guardian-ui-2 | http://127.0.0.1:3001/ |
 | guardian-ui-3 | http://127.0.0.1:3002/ |
@@ -67,8 +67,8 @@ nix-guardian spins up these instances
 yarn nix-gateway
 ```
 nix-gateway spins up these instances
-| ui instance | url | 
-| ----------------- | --- |
+| instance | url | 
+| ---------- | --- |
 | gateway-ui | http://127.0.0.1:3004/ |
 | guardian-ui | http://127.0.0.1:3000/ |
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Fedimint UI releases use semantic versioning (`major.minor.patch`)
 yarn nix-guardian
 ```
 nix-guardian spins up these instances
-| ui instance | uri |
+| ui instance | url |
 | ----------------- | --- |
 | guardian-ui-1 | http://127.0.0.1:3000/ |
 | guardian-ui-2 | http://127.0.0.1:3001/ |
@@ -67,7 +67,7 @@ nix-guardian spins up these instances
 yarn nix-gateway
 ```
 nix-gateway spins up these instances
-| ui instance | uri | 
+| ui instance | url | 
 | ----------------- | --- |
 | gateway-ui | http://127.0.0.1:3004/ |
 | guardian-ui | http://127.0.0.1:3000/ |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ nix-guardian spins up these instances
 ```bash
 yarn nix-gateway
 ```
+nix-gateway spins up these instances
 | ui instance | uri | 
 | ----------------- | --- |
 | gateway-ui | http://127.0.0.1:3004/ |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Fedimint UI releases use semantic versioning (`major.minor.patch`)
    ```bash
    nix develop
    ```
-1. Run `yarn nix-gateway` or `nix-guardian` Note: **nix-gateway** preconfigures the federation so you don't have to go through federation setup. **nix-guardian** starts separate guardian nodes that are connected into the federation when you run through the federation setup process.
+1. Run `yarn nix-gateway` or `yarn nix-guardian` Note: **nix-gateway** preconfigures the federation so you don't have to go through federation setup. **nix-guardian** starts separate guardian nodes that are connected into the federation when you run through the federation setup process.
 
 **guardian-ui**
 ```bash

--- a/README.md
+++ b/README.md
@@ -116,9 +116,13 @@ From root repo directory:
 
 After running through the config setup UI flow once, you will need to delete the `fedimintd` data to run through it again. To do this, delete the `fm_1`, `fm_2`, `fm_3`, and `fm_4` folder from the repo. These are data directories mounted to Docker containers running fedmintd and are listed in `.gitignore` so are safe to remove.
 
-### Running with mprocs
+### Running with Nix and mprocs
 
 1. Install [mprocs](https://github.com/pvolok/mprocs)
+1. Install [Nix](https://nixos.org/download)
+1. Add `experimental-features = nix-command flakes` to your `/etc/nix/nix.conf` file
+1. In a terminal `cd` to the fedimint-ui repo root directory
+1. Run `nix develop`
 1. Run `mprocs -c mprocs.yml`
 
 After running this command, you'll be present with the mprocs display. Along the left side are the list of processes currently available by mprocs. Along the bottom are hotkeys for navigating/interacting with mprocs. The main pane shows the shell output for the currently selected process.
@@ -127,9 +131,17 @@ The `start-servers` process shows combined logging for `fedimintd`, `bitcoind`, 
 
 The `stop-servers` process can be used to stop all docker containers by hitting the `s` key to start the process. After doing so, you can return to the `start-servers` process and hit `r` to restart things.
 
-The `guardian-ui-1` and `guardian-ui-2` are instances of `guardian-ui` apps, each running on different ports and connected to a unique `fedimintd` server instance (running in the `start-servers` process).
+The `guardian-ui-1`, `guardian-ui-2`, `guardian-ui-3`, `guardian-ui-4` are instances of `guardian-ui` apps, each running on different ports and connected to a unique `fedimintd` server instance (running in the `start-servers` process).
 
 The `gateway-ui` is an instance of `gateway-ui` app, connected to a `gatewayd` server instance (running in the `start-servers` process).
+
+| ui instance | uri | api endpoint
+| ----------------- | --- | -------------------------- |
+| guardian-ui-1 | http://127.0.0.1:3000/ | ws://127.0.0.1:18174 |
+| guardian-ui-2 | http://127.0.0.1:3001/ | ws://127.0.0.1:18184 |
+| guardian-ui-3 | http://127.0.0.1:3002/ | ws://127.0.0.1:18185 |
+| guardian-ui-4 | http://127.0.0.1:3003/ | ws://127.0.0.1:18186 |
+| gateway-ui | http://127.0.0.1:3004/ | http://127.0.0.1:8175 |
 
 You can see more details by viewing the `mprocs.yml` file.
 


### PR DESCRIPTION
1. Updated the Readme in the guardian-ui/apps directory to add the additional two guardian ui instances that are now spun up with docker compose.
2. In the repo root Readme, additional details were added on setting up Nix and running mprocs including a table to show the uri information for all instances spun up by the mprocs.yml file.