### PR TITLE
fix: text spacing on verify guardians screen

### DIFF
--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -257,12 +257,16 @@ const WaitingForVerification: React.FC<{ verifiedConfigs: boolean }> = ({
 }) => {
   const { t } = useTranslation();
 
-  return verifiedConfigs ? (
-    <Text>{t('verify-guardians.all-guardians-verified')}</Text>
-  ) : (
-    <>
-      <Spinner />
-      <Text>{t('verify-guardians.wait-all-guardians-verification')}</Text>
-    </>
+  return (
+    <Flex direction='column' height='100%' my={'auto'}>
+      {verifiedConfigs ? (
+        <Text>{t('verify-guardians.all-guardians-verified')}</Text>
+      ) : (
+        <>
+          <Spinner />
+          <Text>{t('verify-guardians.wait-all-guardians-verification')}</Text>
+        </>
+      )}
+    </Flex>
   );
 };

--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -258,7 +258,7 @@ const WaitingForVerification: React.FC<{ verifiedConfigs: boolean }> = ({
   const { t } = useTranslation();
 
   return (
-    <Flex direction='column' height='100%' my={'auto'}>
+    <Flex direction='row' height='100%' my={'auto'}>
       {verifiedConfigs ? (
         <Text>{t('verify-guardians.all-guardians-verified')}</Text>
       ) : (


### PR DESCRIPTION
<img width="585" alt="image" src="https://github.com/fedimint/ui/assets/74332828/e563d9b9-4a00-4a9d-b7ad-178c99aea041">
