### PR TITLE
fix(guardian-ui): add missing qrcode.react package

### DIFF
--- a/apps/guardian-ui/package.json
+++ b/apps/guardian-ui/package.json
@@ -20,6 +20,7 @@
     "framer-motion": "^6",
     "jsonrpc-client-websocket": "^1.5.2",
     "node": "^20.1.0",
+    "qrcode.react": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.7.1",
@@ -27,6 +28,8 @@
     "react-use-websocket": "3.0.0"
   },
   "devDependencies": {
+    "@fedimint/eslint-config": "*",
+    "@fedimint/tsconfig": "*",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.5.0",
@@ -36,8 +39,6 @@
     "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^5.48.1",
     "@typescript-eslint/parser": "^5.48.2",
-    "@fedimint/eslint-config": "*",
-    "@fedimint/tsconfig": "*",
     "eslint": "^8.4.1",
     "prettier": "^2.8.3",
     "typescript": "^5.1.6"


### PR DESCRIPTION
Fixes a regression from #284, the `qrcode.react` module wasn't added to package.json causing docker image builds to fail.