### PR TITLE
Role selector Mobile Updates

### DIFF
--- a/apps/guardian-ui/src/components/RoleSelector.tsx
+++ b/apps/guardian-ui/src/components/RoleSelector.tsx
@@ -55,6 +55,12 @@ export const RoleSelector = React.memo<Props>(function RoleSelector({
 
   return (
     <Flex direction='column' gap={8} align='left' justify='left' maxWidth={660}>
+      <RadioButtonGroup
+        options={options}
+        value={role}
+        onChange={(value) => setRole(value)}
+        activeIcon={CheckIcon}
+      />
       <Alert status='warning'>
         <AlertIcon>
           <WarningIcon />
@@ -66,13 +72,6 @@ export const RoleSelector = React.memo<Props>(function RoleSelector({
           </AlertDescription>
         </Box>
       </Alert>
-      <RadioButtonGroup
-        options={options}
-        value={role}
-        onChange={(value) => setRole(value)}
-        activeIcon={CheckIcon}
-      />
-
       <div>
         <Button
           width={['100%', 'auto']}

--- a/apps/guardian-ui/src/components/RoleSelector.tsx
+++ b/apps/guardian-ui/src/components/RoleSelector.tsx
@@ -66,7 +66,6 @@ export const RoleSelector = React.memo<Props>(function RoleSelector({
           </AlertDescription>
         </Box>
       </Alert>
-
       <RadioButtonGroup
         options={options}
         value={role}
@@ -76,7 +75,7 @@ export const RoleSelector = React.memo<Props>(function RoleSelector({
 
       <div>
         <Button
-          width='auto'
+          width={['100%', 'auto']}
           leftIcon={<Icon as={ArrowRightIcon} />}
           isDisabled={!role}
           onClick={handleNext}

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -63,14 +63,14 @@
   },
   "role-selector": {
     "disclaimer-title": "Fedimint is alpha software",
-    "disclaimer-text": "You are using a very early version of Fedimint. It is recommended to not use mainnet bitcoin for your federation. Please use with caution.",
+    "disclaimer-text": "You are using a very early version of Fedimint. Please use with caution & report issues to the Fedimint developers on Github.",
     "leader": {
-      "label": "Leader",
-      "description": "Choose one of your Guardians as a Leader. The Leader will input information about the Federation."
+      "label": "Setup Leader",
+      "description": "Input configuration settings that other Guardians approve. One Guardian acts as Setup Leader. "
     },
     "follower": {
       "label": "Follower",
-      "description": "Guardian Followers (all other Guardians) will confirm information that the Leader inputs."
+      "description": "Once a Setup Leader sets the configurations, other Guardians choose this option to approve the settings and create the Federation."
     }
   },
   "run-dkg": {
@@ -117,7 +117,7 @@
         "title": "Terms of service"
       },
       "start": {
-        "title": "Welcome to Fedimint!",
+        "title": "Welcome, Guardian!",
         "subtitle": "Are you creating a Federation, or joining one?",
         "step": "Federation details"
       },

--- a/apps/guardian-ui/src/languages/es.json
+++ b/apps/guardian-ui/src/languages/es.json
@@ -69,15 +69,15 @@
     "title": "¡Bienvenido de nuevo!"
   },
   "role-selector": {
-    "disclaimer-text": "Estás utilizando una versión muy temprana de Fedimint. Se recomienda no utilizar bitcoin de la red principal para su federación. Úselo con precaución.",
     "disclaimer-title": "Fedimint es software alfa",
-    "follower": {
-      "description": "Los seguidores del Guardián (todos los demás Guardianes) confirmarán la información que ingrese el Líder.",
-      "label": "Seguidor"
-    },
+    "disclaimer-text": "Estás utilizando una versión muy temprana de Fedimint. Por favor, úsala con precaución e informa de los problemas a los desarrolladores de Fedimint en Github.",
     "leader": {
-      "description": "Elige uno de tus Guardianes como Líder. El Líder ingresará información sobre la Federación.",
-      "label": "Líder"
+      "label": "Líder de Configuración",
+      "description": "Introduce los ajustes de configuración que otros Guardianes aprueban. Un Guardián actúa como Líder de Configuración."
+    },
+    "follower": {
+      "label": "Seguidor",
+      "description": "Una vez que un Líder de Configuración establece las configuraciones, otros Guardianes eligen esta opción para aprobar los ajustes y crear la Federación."
     }
   },
   "run-dkg": {

--- a/apps/guardian-ui/src/languages/ko.json
+++ b/apps/guardian-ui/src/languages/ko.json
@@ -69,15 +69,15 @@
     "title": "돌아온 것을 환영합니다!"
   },
   "role-selector": {
-    "disclaimer-text": "귀하는 매우 초기 버전의 Fedimint를 사용하고 있습니다. 귀하의 연합에는 메인넷 비트코인을 사용하지 않는 것이 좋습니다. 주의해서 사용하십시오.",
+    "disclaimer-text": "귀하는 매우 초기 버전의 Fedimint를 사용하고 있습니다. 주의해서 사용하고 Github의 Fedimint 개발자에게 문제를 보고하세요.",
     "disclaimer-title": "Fedimint는 알파 소프트웨어입니다.",
     "follower": {
-      "description": "가디언 팔로워(다른 가디언 전체)는 리더가 입력한 정보를 확인합니다.",
+      "description": "구성 리더가 구성을 설정하면 다른 보호자가 이 옵션을 선택하여 설정을 승인하고 연합을 만듭니다.",
       "label": "팔로워"
     },
     "leader": {
-      "description": "가디언 중 한 명을 리더로 선택하세요. 리더는 연합에 대한 정보를 입력합니다.",
-      "label": "리더"
+      "description": "다른 보호자가 승인한 구성 설정을 입력하세요. 한 명의 보호자가 설정 리더 역할을 합니다.",
+      "label": "구성 리더"
     }
   },
   "run-dkg": {

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -118,12 +118,12 @@ export const FederationSetup: React.FC = () => {
           </Button>
         )}
         {title && (
-          <Heading size={['sm', 'md']} fontWeight={['medium']}>
+          <Heading size={['sm', 'md']} fontWeight='medium'>
             {title}
           </Heading>
         )}
         {subtitle && (
-          <Text size={['sm', 'md']} fontWeight={['medium']}>
+          <Text size={['sm', 'md']} fontWeight='medium'>
             {subtitle}
           </Text>
         )}

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -118,19 +118,17 @@ export const FederationSetup: React.FC = () => {
           </Button>
         )}
         {title && (
-          <Heading size='md' fontWeight='medium'>
+          <Heading size={['sm', 'md']} fontWeight={['medium']}>
             {title}
           </Heading>
         )}
         {subtitle && (
-          <Text size='md' fontWeight='medium'>
+          <Text size={['sm', 'md']} fontWeight={['medium']}>
             {subtitle}
           </Text>
         )}
       </Flex>
-      <Box mt={2} width='100%'>
-        {content}
-      </Box>
+      <Box width='100%'>{content}</Box>
     </Flex>
   );
 };

--- a/packages/ui/src/Header.tsx
+++ b/packages/ui/src/Header.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
-import { Flex, Spacer } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 
 export const Header = React.memo(function Header() {
   return (
-    <Flex width='100%' mb='32px'>
-      <Flex alignItems='center' gap='2'>
+    <Flex width='100%' mb='32px' justifyContent={['center', 'flex-start']}>
+      <Flex
+        alignItems='center'
+        justifyContent={['center', 'flex-start']}
+        gap='2'
+      >
         <>
           <svg
             width='200'
@@ -41,7 +45,6 @@ export const Header = React.memo(function Header() {
           </svg>
         </>
       </Flex>
-      <Spacer />
     </Flex>
   );
 });

--- a/packages/ui/src/RadioButtonGroup.tsx
+++ b/packages/ui/src/RadioButtonGroup.tsx
@@ -53,7 +53,6 @@ export function RadioButtonGroup<T extends string | number>({
             variant='outline'
             p={4}
             width='full'
-            height='auto' // Changed from fixed height to auto
             borderRadius={12}
             textAlign='left'
             margin={0}
@@ -70,24 +69,22 @@ export function RadioButtonGroup<T extends string | number>({
                 bg={theme.colors.blue[100]}
                 boxShadow={`0 0 0 6px ${theme.colors.blue[50]}`}
                 borderRadius='100%'
-                // Ensure icons fit well and are not too large
-                p={1} // Adjust padding around the icon
+                p={1}
               >
-                <Icon as={option.icon} boxSize='24px' />
+                <Icon as={option.icon} />
               </Flex>
               <Flex
                 direction='column'
                 align='start'
                 flex={1}
                 minWidth={0}
-                wrap='nowrap' // Changed to nowrap
                 gap={2}
               >
                 <Text
                   size={['md', 'lg']}
                   fontWeight='medium'
                   color={isActive ? theme.colors.blue[800] : undefined}
-                  isTruncated // Add truncation to prevent overflow
+                  isTruncated
                 >
                   {option.label}
                 </Text>
@@ -95,7 +92,6 @@ export function RadioButtonGroup<T extends string | number>({
                   size={['sm', 'md']}
                   variant='secondary'
                   fontWeight='normal'
-                  whiteSpace='normal' // Ensure text wraps and does not overflow
                   color={isActive ? theme.colors.blue[700] : undefined}
                 >
                   {option.description}

--- a/packages/ui/src/RadioButtonGroup.tsx
+++ b/packages/ui/src/RadioButtonGroup.tsx
@@ -51,10 +51,9 @@ export function RadioButtonGroup<T extends string | number>({
             key={option.value}
             onClick={() => onChange(option.value)}
             variant='outline'
-            pl={4}
-            pr={4}
+            p={4}
             width='full'
-            height={106}
+            height='auto' // Changed from fixed height to auto
             borderRadius={12}
             textAlign='left'
             margin={0}
@@ -71,28 +70,32 @@ export function RadioButtonGroup<T extends string | number>({
                 bg={theme.colors.blue[100]}
                 boxShadow={`0 0 0 6px ${theme.colors.blue[50]}`}
                 borderRadius='100%'
-                mixBlendMode='multiply'
+                // Ensure icons fit well and are not too large
+                p={1} // Adjust padding around the icon
               >
-                <Icon as={option.icon} />
+                <Icon as={option.icon} boxSize='24px' />
               </Flex>
               <Flex
                 direction='column'
                 align='start'
                 flex={1}
                 minWidth={0}
-                wrap='wrap'
+                wrap='nowrap' // Changed to nowrap
                 gap={2}
               >
                 <Text
+                  size={['md', 'lg']}
                   fontWeight='medium'
                   color={isActive ? theme.colors.blue[800] : undefined}
+                  isTruncated // Add truncation to prevent overflow
                 >
                   {option.label}
                 </Text>
                 <Text
+                  size={['sm', 'md']}
                   variant='secondary'
                   fontWeight='normal'
-                  whiteSpace='break-spaces'
+                  whiteSpace='normal' // Ensure text wraps and does not overflow
                   color={isActive ? theme.colors.blue[700] : undefined}
                 >
                   {option.description}


### PR DESCRIPTION
Makes several changes to the Role Selector page:

Old:
<img width="868" alt="image" src="https://github.com/fedimint/ui/assets/74332828/12591f0f-3424-4eb6-b9ef-84f621dec5b2">


New:

<img width="823" alt="image" src="https://github.com/fedimint/ui/assets/74332828/9fcf6e20-e343-4d6e-a202-777c8f7a6ec5">


1. Updates to copy:
- Change to "Welcome, Guardian" to avoid stacking big "Fedimint" and make it easier to fit title on mobile screen
- Setup Leader: slarifies that it's just for setup, not a difference among guardians
- Follower: Clarifies their role as after setup leader and that that's when the actual federation gets set up.
- Removes mainnet warning: we should do the mainnet warnings on the leader configuration page if they actually select mainnet, not preemptively. Also tells ppl to file issues with us.

2. Moves warning below role selector, above next button:
- On mobile the big warning pushes the follower option below the fold, this looks and makes it more like an "acknowledge by clicking next"

3. Fixes mobile UI layout
- Fixes overflows in radiobuttongroup children
- centers header on mobile (will be centered across all mobile pages)
- 100% width for next button