### PR TITLE
fix: center header

### DIFF
--- a/packages/ui/src/Header.tsx
+++ b/packages/ui/src/Header.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Flex, Spacer } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 
 export const Header = React.memo(function Header() {
   return (
-    <Flex width='100%' mb='32px'>
+    <Flex width='100%' mb='32px' justifyContent={'center'}>
       <Flex alignItems='center' gap='2'>
         <>
           <svg
@@ -41,7 +41,6 @@ export const Header = React.memo(function Header() {
           </svg>
         </>
       </Flex>
-      <Spacer />
     </Flex>
   );
 });


### PR DESCRIPTION
Centers header on all screens to match figma, also looks better on both desktop and mobile for gateway and guardian

<img width="379" alt="image" src="https://github.com/fedimint/ui/assets/74332828/3ba0854b-c36e-43e2-b326-159ff84fb81b">
<img width="382" alt="image" src="https://github.com/fedimint/ui/assets/74332828/b258b844-d810-4972-99a4-e6a51602b386">

<img width="859" alt="image" src="https://github.com/fedimint/ui/assets/74332828/6dee4e7f-0da3-498f-aff2-8548a93e865f">
