### PR TITLE
Leader mobile UI SetConfigurations

### DIFF
--- a/apps/guardian-ui/src/assets/svgs/lightbulb.svg
+++ b/apps/guardian-ui/src/assets/svgs/lightbulb.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 16.584V18.9996C10 20.1042 10.8954 20.9996 12 20.9996C13.1046 20.9996 14 20.1042 14 18.9996L14 16.584M12 3V4M18.3643 5.63574L17.6572 6.34285M5.63574 5.63574L6.34285 6.34285M4 12H3M21 12H20M17 12C17 14.7614 14.7614 17 12 17C9.23858 17 7 14.7614 7 12C7 9.23858 9.23858 7 12 7C14.7614 7 17 9.23858 17 12Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -13,13 +13,14 @@ import {
   FormErrorMessage,
 } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
-import { FormGroup, FormGroupHeading } from '@fedimint/ui';
+import { FormGroup } from '@fedimint/ui';
 import { useSetupContext } from '../hooks';
 import { BitcoinRpc, ConfigGenParams, GuardianRole, Network } from '../types';
 import { ReactComponent as FedimintLogo } from '../assets/svgs/fedimint.svg';
 import { ReactComponent as BitcoinLogo } from '../assets/svgs/bitcoin.svg';
 import { ReactComponent as ModulesIcon } from '../assets/svgs/modules.svg';
 import { ReactComponent as ArrowRightIcon } from '../assets/svgs/arrow-right.svg';
+import { ReactComponent as LightbulbLogo } from '../assets/svgs/lightbulb.svg';
 import {
   formatApiErrorMessage,
   getModuleParamsFromConfig,
@@ -198,8 +199,12 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
   };
 
   return (
-    <Flex direction='column' gap={10} justify='start' align='start'>
-      <FormGroup>
+    <Flex direction='column' gap={['2', '6']} justify='start' align='start'>
+      <FormGroup
+        icon={LightbulbLogo}
+        title={`${t('set-config.basic-settings')}`}
+        isOpen={true}
+      >
         <FormControl>
           <FormLabel>{t('set-config.guardian-name')}</FormLabel>
           <Input
@@ -249,11 +254,11 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
       </FormGroup>
       <>
         {isHost && (
-          <FormGroup>
-            <FormGroupHeading
-              icon={FedimintLogo}
-              title={`${t('set-config.federation-settings')}`}
-            />
+          <FormGroup
+            icon={FedimintLogo}
+            title={`${t('set-config.federation-settings')}`}
+            isOpen={true}
+          >
             <FormControl>
               <FormLabel>{t('set-config.federation-name')}</FormLabel>
               <Input
@@ -272,8 +277,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
             />
           </FormGroup>
         )}
-        <FormGroup>
-          <FormGroupHeading icon={BitcoinLogo} title='Bitcoin settings' />
+        <FormGroup icon={BitcoinLogo} title='Bitcoin settings' isOpen={false}>
           {isHost && (
             <>
               <NumberFormControl
@@ -319,33 +323,33 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
           </FormControl>
         </FormGroup>
         {isHost && (
-          <FormGroup maxWidth={470}>
-            <FormGroupHeading
-              icon={ModulesIcon}
-              title={t('set-config.meta-fields')}
-            />
+          <FormGroup
+            icon={ModulesIcon}
+            title={t('set-config.meta-fields')}
+            isOpen={false}
+          >
             <MetaFieldFormControl
               metaFields={metaFields}
               onChangeMetaFields={setMetaFields}
             />
           </FormGroup>
         )}
-      </>
-      {error && (
-        <Text color={theme.colors.red[500]} mt={4}>
-          {error}
-        </Text>
-      )}
-      <div>
+        {error && (
+          <Text color={theme.colors.red[500]} mt={4}>
+            {error}
+          </Text>
+        )}
         <Button
           isDisabled={!isValid}
           onClick={isValid ? handleNext : undefined}
           leftIcon={<Icon as={ArrowRightIcon} />}
-          mt={4}
+          justifySelf='start'
+          mt={['2', '4']}
+          width={['100%', 'auto']}
         >
           {t('common.next')}
         </Button>
-      </div>
+      </>
     </Flex>
   );
 };

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -339,16 +339,24 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
             {error}
           </Text>
         )}
-        <Button
-          isDisabled={!isValid}
-          onClick={isValid ? handleNext : undefined}
-          leftIcon={<Icon as={ArrowRightIcon} />}
-          justifySelf='start'
-          mt={['2', '4']}
-          width={['100%', 'auto']}
+        <Flex
+          direction='row'
+          justify='space-between'
+          alignSelf='center'
+          width={['100%', '100%', '60%']}
         >
-          {t('common.next')}
-        </Button>
+          <Button
+            isDisabled={!isValid}
+            onClick={isValid ? handleNext : undefined}
+            leftIcon={<Icon as={ArrowRightIcon} />}
+            justifySelf='center'
+            alignSelf='center'
+            mt={['2', '4']}
+            width={['100%', 'auto']}
+          >
+            {t('common.next')}
+          </Button>
+        </Flex>
       </>
     </Flex>
   );

--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -221,8 +221,8 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
   } else {
     return (
       <Flex direction='column' gap={10} justify='start' align='start'>
-        <FormGroup maxWidth={400}>
-          <FormControl bg={theme.colors.blue[50]} p={2} borderRadius='md'>
+        <FormGroup title={t('verify-guardians.verification-code-title')}>
+          <FormControl>
             <FormLabel>{t('verify-guardians.verification-code')}</FormLabel>
             <CopyInput
               value={myHash}

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -90,6 +90,7 @@
     "error-password-mismatch": "Passwords don't match",
     "join-federation": "Join Federation link",
     "join-federation-help": "Ask the person who created the Federation for a link, and paste it here.",
+    "basic-settings": "Basics",
     "federation-settings": "Federation settings",
     "federation-name": "Federation name",
     "guardian-number": "Number of guardians",

--- a/apps/guardian-ui/src/languages/es.json
+++ b/apps/guardian-ui/src/languages/es.json
@@ -102,6 +102,7 @@
     "error-valid-max": "Por favor ingrese un número de como máximo {{max}}.",
     "error-valid-min-max": "Por favor ingrese un número entre {{min}} y {{max}}.",
     "federation-name": "Nombre de la Federación",
+    "basic-settings": "Configuración básica",
     "federation-settings": "Configuración de la Federación",
     "guardian-name": "Nombre del Guardián",
     "guardian-name-help": "Este nombre se mostrará a otros Guardianes",

--- a/apps/guardian-ui/src/languages/ko.json
+++ b/apps/guardian-ui/src/languages/ko.json
@@ -102,6 +102,7 @@
     "error-valid-max": "최대한 {{max}} 이하의 숫자를 입력해주세요.",
     "error-valid-min-max": "{{min}}에서 {{max}} 사이의 숫자를 입력해주세요.",
     "federation-name": "연합 이름",
+    "basic-settings": "기본 설정",
     "federation-settings": "연합 설정",
     "guardian-name": "가디언 이름",
     "guardian-name-help": "다른 가디언에게 표시될 이름입니다.",

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -127,7 +127,7 @@ export const FederationSetup: React.FC = () => {
           </Heading>
         )}
         {subtitle && (
-          <Text size={['sm', 'md']} fontWeight='medium'>
+          <Text size={['sm', 'md']} fontWeight='medium' alignSelf='start'>
             {subtitle}
           </Text>
         )}

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -103,11 +103,15 @@ export const FederationSetup: React.FC = () => {
   }
 
   return (
-    <Flex direction='column' gap={10} align='start'>
+    <Flex
+      direction='column'
+      gap={[2, 10]}
+      align={progressIdx === 0 ? 'start' : 'center'}
+    >
       {progressIdx === 0 || !progressIdx ? null : (
         <SetupStepper setupProgress={progressIdx} isHost={isHost} />
       )}
-      <Flex direction='column' align='start' gap={4}>
+      <Flex direction='column' gap={[2, 10]} align='start'>
         {prevProgress && canGoBack && (
           <Button
             variant='link'
@@ -128,7 +132,9 @@ export const FederationSetup: React.FC = () => {
           </Text>
         )}
       </Flex>
-      <Box width='100%'>{content}</Box>
+      <Box width='100%' justifyItems='center'>
+        {content}
+      </Box>
     </Flex>
   );
 };

--- a/packages/ui/src/FormGroup.tsx
+++ b/packages/ui/src/FormGroup.tsx
@@ -1,19 +1,43 @@
-import React from 'react';
-import { Flex } from '@chakra-ui/react';
+import React, { useState } from 'react';
+import { Flex, Collapse } from '@chakra-ui/react';
+import { FormGroupHeading } from './FormGroupHeading';
 
 interface Props {
   children: React.ReactNode;
   maxWidth?: number;
+  title: React.ReactNode;
+  icon?: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+  isOpen?: boolean;
 }
 
-export const FormGroup: React.FC<Props> = ({ children, maxWidth = 320 }) => (
-  <Flex
-    direction='column'
-    gap={6}
-    align='start'
-    width='100%'
-    maxWidth={maxWidth}
-  >
-    {children}
-  </Flex>
-);
+export const FormGroup: React.FC<Props> = ({
+  children,
+  title,
+  icon,
+  isOpen,
+}) => {
+  const [open, setOpen] = useState(isOpen ?? true);
+
+  return (
+    <Flex
+      direction='column'
+      gap={['2', '6']}
+      alignSelf='center'
+      justifySelf='center'
+      w={['100%', '100%', '60%']}
+      fontSize='sm'
+    >
+      <FormGroupHeading
+        icon={icon}
+        title={title}
+        onClick={() => setOpen(!open)}
+        chevronIcon={
+          open
+            ? String.fromCharCode(0x25b4)
+            : String.fromCharCode(0x25be) + ' Show Fields'
+        }
+      />
+      <Collapse in={open}>{children}</Collapse>
+    </Flex>
+  );
+};

--- a/packages/ui/src/FormGroupHeading.tsx
+++ b/packages/ui/src/FormGroupHeading.tsx
@@ -1,14 +1,37 @@
 import React from 'react';
-import { Flex, Icon, Heading } from '@chakra-ui/react';
+import { Flex, Icon, Heading, Spacer, useTheme } from '@chakra-ui/react';
 
-export const FormGroupHeading: React.FC<{
+interface Props {
   icon?: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
   title: React.ReactNode;
-}> = ({ icon, title }) => (
-  <Flex align='center' justify='start' mb={icon ? -3 : 3}>
-    {icon && <Icon width='20px' height='20px' mr={2} as={icon} />}
-    <Heading fontSize='md' lineHeight='20px' fontWeight='700'>
-      {title}
-    </Heading>
-  </Flex>
-);
+  onClick?: () => void;
+  chevronIcon?: string;
+}
+
+export const FormGroupHeading: React.FC<Props> = ({
+  icon,
+  title,
+  onClick,
+  chevronIcon,
+}) => {
+  const theme = useTheme();
+  return (
+    <Flex
+      align='center'
+      justify='start'
+      mb={3}
+      bg={theme.colors.gray[100]}
+      p={2}
+      borderRadius={8}
+      w='100%'
+      onClick={onClick}
+    >
+      {icon && <Icon width='20px' height='20px' mr={2} as={icon} />}
+      <Heading fontSize='md' lineHeight='20px' fontWeight='700'>
+        {title}
+      </Heading>
+      <Spacer />
+      {chevronIcon}
+    </Flex>
+  );
+};

--- a/packages/ui/src/RadioButtonGroup.tsx
+++ b/packages/ui/src/RadioButtonGroup.tsx
@@ -53,6 +53,7 @@ export function RadioButtonGroup<T extends string | number>({
             variant='outline'
             p={4}
             width='full'
+            height='auto'
             borderRadius={12}
             textAlign='left'
             margin={0}
@@ -92,6 +93,7 @@ export function RadioButtonGroup<T extends string | number>({
                   size={['sm', 'md']}
                   variant='secondary'
                   fontWeight='normal'
+                  whiteSpace='break-spaces'
                   color={isActive ? theme.colors.blue[700] : undefined}
                 >
                   {option.description}


### PR DESCRIPTION
Fixes mobile UI for set configurations leader setup per new figma specification on desktop and mobile:

Doesn't fix header spacing of Left of dashboard / role selector but middle on intermediate setup, will have to handle in a separate PR because Header doesn't inherit what setup progression step the user is in.

New:

<img width="1022" alt="image" src="https://github.com/fedimint/ui/assets/74332828/1b6cd125-182f-4ad0-b748-19d891e2eb96">

<img width="389" alt="image" src="https://github.com/fedimint/ui/assets/74332828/e14ee7d0-07cc-457c-beba-dbe7a348bea3">
