### PR TITLE
fix: lightning gateway dashboard changes

### DIFF
--- a/apps/gateway-ui/src/components/BalanceCard.tsx
+++ b/apps/gateway-ui/src/components/BalanceCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Text, useTheme } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
-import { GatewayCard } from './GatewayCard';
+import { FedNameCard } from './FedNameCard';
 
 interface BalanceCardProps {
   balance_msat: number;
+  federationName: string;
 }
 
 export const BalanceCard = React.memo(function BalanceCard(
@@ -15,18 +16,21 @@ export const BalanceCard = React.memo(function BalanceCard(
   const theme = useTheme();
 
   return (
-    <GatewayCard
-      title={t('balance-card.card_header')}
-      description={t('balance-card.sentence')}
+    <FedNameCard
+      title={t('federation-card.default-federation-name')}
+      federationName={props.federationName}
     >
+      <Text variant='secondary' size='sm'>
+        {t('balance-card.your-balance')}
+      </Text>
       <Text
-        fontSize='24px'
+        fontSize='xl'
         fontWeight='600'
         color={theme.colors.gray[800]}
         fontFamily={theme.fonts.body}
       >
-        {balance_msat / 1000}
+        {balance_msat / 1000} {'sats'}
       </Text>
-    </GatewayCard>
+    </FedNameCard>
   );
 });

--- a/apps/gateway-ui/src/components/DepositCard.tsx
+++ b/apps/gateway-ui/src/components/DepositCard.tsx
@@ -53,7 +53,7 @@ export const DepositCard = React.memo(function DepositCard({
 
   return (
     <GatewayCard
-      title={t('deposit-card.card_header')}
+      title={t('deposit-card.card_header') + '(BTC -> eCash)'}
       description={t('deposit-card.sentence-one')}
     >
       <Stack spacing='24px'>

--- a/apps/gateway-ui/src/components/FedNameCard.tsx
+++ b/apps/gateway-ui/src/components/FedNameCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Card, CardBody, CardHeader, Text } from '@chakra-ui/react';
+
+export interface FedNameCardProps {
+  title: string;
+  federationName?: string;
+  children: React.ReactNode;
+}
+
+export const FedNameCard = React.memo(function FedNameCard({
+  title,
+  federationName,
+  children,
+}: FedNameCardProps) {
+  return (
+    <Card w='100%' maxWidth='100%'>
+      <CardHeader>
+        <Text variant='secondary' size='sm'>
+          {title}
+        </Text>
+        {federationName && (
+          <Text size='xl' fontWeight='600'>
+            {federationName}
+          </Text>
+        )}
+      </CardHeader>
+      <CardBody>{children}</CardBody>
+    </Card>
+  );
+});

--- a/apps/gateway-ui/src/components/FederationCard.tsx
+++ b/apps/gateway-ui/src/components/FederationCard.tsx
@@ -27,11 +27,13 @@ export const FederationCard: React.FC<FederationCardProps> = ({
           color={theme.colors.gray[900]}
           fontFamily={theme.fonts.heading}
         >
-          {config.meta.federation_name ||
-            t('federation-card.default-federation-name')}
+          {t('header.title')}
         </Heading>
         <Flex gap='24px' flexDir={{ base: 'column', sm: 'column', md: 'row' }}>
-          <BalanceCard balance_msat={balance_msat} />
+          <BalanceCard
+            balance_msat={balance_msat}
+            federationName={config.meta.federation_name || federation_id}
+          />
           <InfoCard nodeId={federation_id} network={network} />
         </Flex>
         <Flex gap='24px' flexDir={{ base: 'column', sm: 'column', md: 'row' }}>

--- a/apps/gateway-ui/src/components/WithdrawCard.tsx
+++ b/apps/gateway-ui/src/components/WithdrawCard.tsx
@@ -178,7 +178,7 @@ export const WithdrawCard = React.memo(function WithdrawCard({
             fontSize='sm'
             onClick={createWithdrawal}
           >
-            {t('withdraw-card.card-header')}
+            {t('withdraw-card.withdraw')}
           </Button>
         </Stack>
       </GatewayCard>

--- a/apps/gateway-ui/src/components/WithdrawCard.tsx
+++ b/apps/gateway-ui/src/components/WithdrawCard.tsx
@@ -93,7 +93,7 @@ export const WithdrawCard = React.memo(function WithdrawCard({
   return (
     <>
       <GatewayCard
-        title={t('withdraw-card.card-header')}
+        title={t('withdraw-card.card-header') + '(eCash -> BTC)'}
         description={`${t('withdraw-card.total_bitcoin')} ${formatMsatsToBtc(
           balanceMsat as MSats
         )} ${t('common.btc')}`}

--- a/apps/gateway-ui/src/languages/en.json
+++ b/apps/gateway-ui/src/languages/en.json
@@ -20,7 +20,8 @@
   },
   "balance-card": {
     "card_header": "eCash balance",
-    "sentence": "Denominated in Sats"
+    "sentence": "Denominated in Sats",
+    "your-balance": "Your eCash balance on this federation:"
   },
   "connect-federation": {
     "connect": "Connect 🚀",
@@ -34,7 +35,7 @@
   },
   "deposit-card": {
     "bitcoin-deposit": "Bitcoin Deposit",
-    "card_header": "Deposit Bitcoin",
+    "card_header": "Deposit Bitcoin (BTC -> eCash)",
     "confirmations": "Confirmations:",
     "header": "Bitcoin Deposit to Federation",
     "receiving-address": "Receiving Addr",
@@ -43,7 +44,7 @@
     "transaction-id": "Transaction ID"
   },
   "federation-card": {
-    "default-federation-name": "Your federation",
+    "default-federation-name": "Your connected federation: ",
     "view-link-on": "View on {{host}}"
   },
   "footer": {
@@ -66,17 +67,18 @@
     "date-created": "Date Created",
     "descending": "Descending",
     "filter": "Filter",
-    "sort": "Sort"
+    "sort": "Sort",
+    "title": "Lightning Gateway Dashboard"
   },
   "info-card": {
-    "card_header": "Node ID"
+    "card_header": "Lightning Node ID"
   },
   "withdraw-card": {
     "address-label": "Your address:",
     "address-placeholder": "Enter your btc address",
     "amount-label": "Amount (sats):",
     "amount-placeholder": "Enter amount in sats",
-    "card-header": "Withdraw Bitcoin",
+    "card-header": "Withdraw Bitcoin (eCash -> BTC)",
     "close": "Close",
     "confirm-withdraw": "Confirm Withdraw",
     "error": "Error",

--- a/apps/gateway-ui/src/languages/en.json
+++ b/apps/gateway-ui/src/languages/en.json
@@ -35,7 +35,7 @@
   },
   "deposit-card": {
     "bitcoin-deposit": "Bitcoin Deposit",
-    "card_header": "Deposit Bitcoin (BTC -> eCash)",
+    "card_header": "Deposit Bitcoin",
     "confirmations": "Confirmations:",
     "header": "Bitcoin Deposit to Federation",
     "receiving-address": "Receiving Addr",
@@ -78,7 +78,7 @@
     "address-placeholder": "Enter your btc address",
     "amount-label": "Amount (sats):",
     "amount-placeholder": "Enter amount in sats",
-    "card-header": "Withdraw Bitcoin (eCash -> BTC)",
+    "card-header": "Withdraw Bitcoin",
     "close": "Close",
     "confirm-withdraw": "Confirm Withdraw",
     "error": "Error",

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -47,7 +47,7 @@
     },
     "gateways": {
       "label": "Lightning Gateways",
-      "node-id-label": "Node ID",
+      "node-id-label": "Lightning Node ID",
       "gateway-id-label": "Gateway ID",
       "fee-label": "Gateway fee",
       "view-on-site": "View on {{site}}",


### PR DESCRIPTION
Made some copy changes per discussions from design call earlier:

1. Change top title to "Lightning Gateway Dashboard" to make it more clear (currently easily confused with guardian dashboard)
2. Move federation name onto balance card
3. Add clarifications to deposit and withdraw for which direction ecash is going, people have found that confusing "So if I deposit bitcoin then that means I get ecash?", it's unintuitive.

<img width="1278" alt="image" src="https://github.com/fedimint/ui/assets/74332828/c57643b9-a367-4e11-b930-597befdc7cdb">
