### PR TITLE
chore: bump fedimint to release/v0.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,17 +98,16 @@
         "nixpkgs-unstable": "nixpkgs-unstable_2"
       },
       "locked": {
-        "lastModified": 1701251322,
-        "narHash": "sha256-og7C8Q19KsHf4HCsgiI1CbNEWk4kUcArtiitWteTXpw=",
+        "lastModified": 1701451267,
+        "narHash": "sha256-J1aZhHFBIB04c185bwqCF23j1e3ts45d3m+YDMhjB6E=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "bbe587845935517df8a36b9b2a6b98fa4bc1e19e",
+        "rev": "369aacdc479030a45f6212e05da06baebbdc1237",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "bbe587845935517df8a36b9b2a6b98fa4bc1e19e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,19 +2,14 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
-    fedimint = {
-      url = "github:fedimint/fedimint?rev=bbe587845935517df8a36b9b2a6b98fa4bc1e19e";
-    };
+    fedimint = { url = "github:fedimint/fedimint?branch=releases/0.2"; };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+        pkgs = import nixpkgs { inherit system; };
         fmLib = fedimint.lib.${system};
-      in
-      {
+      in {
         devShells = fmLib.devShells // {
           default = fmLib.devShells.default.overrideAttrs (prev: {
             nativeBuildInputs = [


### PR DESCRIPTION
Bumps to v0.2 branch that we're backporting fedimint side changes onto.