### PR TITLE
chore: bump fedimint to 0.2.0-rc5

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ From root repo directory:
 
 ## Referencing Fedimint
 
-The docker containers and devimint are for specific releases or commits of `fedimint/fedimint`. At present, the reference commit-hash is `bbe587845935517df8a36b9b2a6b98fa4bc1e19e`
+The docker containers and devimint are for specific releases or commits of `fedimint/fedimint`. At present, the reference commit-hash is `24113a64b270bf2ecb49b8f4554ba975025711db`
 
 ### Running with local Fedimint
 
@@ -209,6 +209,6 @@ This will put binaries in `fedimint/target/debug` at the front of your `$PATH`. 
 You can officially bump the referenced version of Fedimint using the following steps:
 
 1. Locate a desired hash from [Fedimint](https://github.com/fedimint/fedimint/commits/master)
-2. Find and replace all instances of the current reference commit hash: `bbe587845935517df8a36b9b2a6b98fa4bc1e19e`
+2. Find and replace all instances of the current reference commit hash: `24113a64b270bf2ecb49b8f4554ba975025711db`
 3. Run `nix flake update` at the root of the repo
 4. Restart your nix shell and validate the reference, then commit to complete bump

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   fedimintd_1:
     # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
-    image: fedimint/fedimintd:bbe587845935517df8a36b9b2a6b98fa4bc1e19e
+    image: fedimint/fedimintd:24113a64b270bf2ecb49b8f4554ba975025711db
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18173
@@ -21,7 +21,7 @@ services:
 
   gatewayd_1:
     # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
-    image: fedimint/gatewayd:bbe587845935517df8a36b9b2a6b98fa4bc1e19e
+    image: fedimint/gatewayd:24113a64b270bf2ecb49b8f4554ba975025711db
     command: gatewayd lnd
     environment:
       # Path to folder containing gateway config and data files
@@ -61,7 +61,7 @@ services:
 
   fedimintd_2:
     # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
-    image: fedimint/fedimintd:bbe587845935517df8a36b9b2a6b98fa4bc1e19e
+    image: fedimint/fedimintd:24113a64b270bf2ecb49b8f4554ba975025711db
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18173
@@ -85,7 +85,7 @@ services:
 
   fedimintd_3:
     # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
-    image: fedimint/fedimintd:bbe587845935517df8a36b9b2a6b98fa4bc1e19e
+    image: fedimint/fedimintd:24113a64b270bf2ecb49b8f4554ba975025711db
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18174
@@ -103,7 +103,7 @@ services:
 
   fedimintd_4:
     # Snapshot of Fedimint after AlephBFT was merged: https://github.com/fedimint/fedimint/pull/3313
-    image: fedimint/fedimintd:bbe587845935517df8a36b9b2a6b98fa4bc1e19e
+    image: fedimint/fedimintd:24113a64b270bf2ecb49b8f4554ba975025711db
     environment:
       - FM_DATA_DIR=/data
       - FM_BIND_P2P=0.0.0.0:18175

--- a/flake.lock
+++ b/flake.lock
@@ -98,17 +98,17 @@
         "nixpkgs-unstable": "nixpkgs-unstable_2"
       },
       "locked": {
-        "lastModified": 1701251322,
-        "narHash": "sha256-og7C8Q19KsHf4HCsgiI1CbNEWk4kUcArtiitWteTXpw=",
+        "lastModified": 1701787679,
+        "narHash": "sha256-s8yXBMiaT75022xyyvHNp3U2c9rwYLBzZEm0wIJx8r0=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "bbe587845935517df8a36b9b2a6b98fa4bc1e19e",
+        "rev": "24113a64b270bf2ecb49b8f4554ba975025711db",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "bbe587845935517df8a36b9b2a6b98fa4bc1e19e",
+        "rev": "24113a64b270bf2ecb49b8f4554ba975025711db",
         "type": "github"
       }
     },
@@ -198,11 +198,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1701053011,
-        "narHash": "sha256-8QQ7rFbKFqgKgLoaXVJRh7Ik5LtI3pyBBCfOnNOGkF0=",
+        "lastModified": 1701540982,
+        "narHash": "sha256-5ajSy6ODgGmAbmymRdHnjfVnuVrACjI8wXoGVvrtvww=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b528f99f73c4fad127118a8c1126b5e003b01a9",
+        "rev": "6386d8aafc28b3a7ed03880a57bdc6eb4465491d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      url = "github:fedimint/fedimint?rev=bbe587845935517df8a36b9b2a6b98fa4bc1e19e";
+      url = "github:fedimint/fedimint?rev=24113a64b270bf2ecb49b8f4554ba975025711db";
     };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:


### PR DESCRIPTION
Replaces #334, sticking with commit hash and updating to rc5 (I think that PR was still rc4?)