### PR TITLE
fix: decode string responses as json for address and deposit txid

### DIFF
--- a/apps/gateway-ui/src/GatewayApi.ts
+++ b/apps/gateway-ui/src/GatewayApi.ts
@@ -85,7 +85,7 @@ export class GatewayApi {
       });
 
       if (res.ok) {
-        const address: string = (await res.text()).replace(/"/g, '').trim();
+        const address: string = await res.json();
         return Promise.resolve(address);
       }
 
@@ -128,7 +128,7 @@ export class GatewayApi {
       });
 
       if (res.ok) {
-        const txid: string = await res.text();
+        const txid: string = await res.json();
         console.log('txid', txid);
         return Promise.resolve(txid);
       }


### PR DESCRIPTION
Closes #338. Replaces both instances of a string response with `res.json()`, not just for objects after all!