### PR TITLE
fix: trashcan icon for custom meta fields

### DIFF
--- a/apps/guardian-ui/src/components/MetaFieldFormControl.tsx
+++ b/apps/guardian-ui/src/components/MetaFieldFormControl.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Flex,
   FormControl,
@@ -62,7 +63,7 @@ export const MetaFieldFormControl: React.FC<Props> = ({
         {metaFields.map(([key, value], idx) => {
           const isDerived = derivedMetaKeys.includes(key);
           return (
-            <Flex gap={3} key={idx}>
+            <Flex gap={2} key={idx} align='center'>
               <Input
                 placeholder={t('set-config.meta-fields-key')}
                 value={key}
@@ -79,10 +80,10 @@ export const MetaFieldFormControl: React.FC<Props> = ({
                   handleChangeMetaField(key, ev.target.value, idx)
                 }
               />
-              {!isDerived && (
+              {isDerived ? (
+                <Box width={'58px'} height={'42px'} opacity={0} /> // Invisible placeholder
+              ) : (
                 <IconButton
-                  position='absolute'
-                  left='100%'
                   variant='ghost'
                   size='xs'
                   width={'42px'}


### PR DESCRIPTION
<img width="745" alt="image" src="https://github.com/fedimint/ui/assets/74332828/77608255-2f53-42c2-a36c-40082bb14f33">

fixes #344 

Having the box for the Derived ones makes the spacing look nicer, tried both ways and when you don't leave the spacing then the center gap looks weird.