### PR TITLE
chore: bump fedimint version to 0.2.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,17 +98,17 @@
         "nixpkgs-unstable": "nixpkgs-unstable_2"
       },
       "locked": {
-        "lastModified": 1701787679,
-        "narHash": "sha256-s8yXBMiaT75022xyyvHNp3U2c9rwYLBzZEm0wIJx8r0=",
+        "lastModified": 1704316564,
+        "narHash": "sha256-cuAIJniPQKXfwfl2RBon5iHAaB88GUBjQ1g0IpJwipk=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "24113a64b270bf2ecb49b8f4554ba975025711db",
+        "rev": "a8422b84102ab5fc768307215d5b20d807143f27",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "24113a64b270bf2ecb49b8f4554ba975025711db",
+        "rev": "a8422b84102ab5fc768307215d5b20d807143f27",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,18 +3,16 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      url = "github:fedimint/fedimint?rev=24113a64b270bf2ecb49b8f4554ba975025711db";
+      url =
+        "github:fedimint/fedimint?rev=a8422b84102ab5fc768307215d5b20d807143f27";
     };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+        pkgs = import nixpkgs { inherit system; };
         fmLib = fedimint.lib.${system};
-      in
-      {
+      in {
         devShells = fmLib.devShells // {
           default = fmLib.devShells.default.overrideAttrs (prev: {
             nativeBuildInputs = [


### PR DESCRIPTION
tested 4x and solo guardian setups + lightning gateway. I'd already fixed for working with rc-3 and was using that with clovyr the past couple weeks.