### PR TITLE
Restart federation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ From root repo directory:
 
 ## Referencing Fedimint
 
-The docker containers and devimint are for specific releases or commits of `fedimint/fedimint`. At present, the reference commit-hash is `a8422b84102ab5fc768307215d5b20d807143f27`
+The docker containers and devimint are for specific releases or commits of `fedimint/fedimint`. At present, the reference commit-hash is `9ec5418ee002134188d4584cc645fe1b5ffba4f1`
 
 ### Running with local Fedimint
 
@@ -209,7 +209,7 @@ This will put binaries in `fedimint/target/debug` at the front of your `$PATH`. 
 You can officially bump the referenced version of Fedimint using the following steps:
 
 1. Locate a desired hash from [Fedimint](https://github.com/fedimint/fedimint/commits/master)
-2. Find and replace all instances of the current reference commit hash: `a8422b84102ab5fc768307215d5b20d807143f27`
+2. Find and replace all instances of the current reference commit hash: `9ec5418ee002134188d4584cc645fe1b5ffba4f1`
 
 3. Run `nix flake update` at the root of the repo
 4. Restart your nix shell and validate the reference, then commit to complete bump

--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -189,6 +189,7 @@ enum SetupRpc {
   runDkg = 'run_dkg',
   verifiedConfigs = 'verified_configs',
   startConsensus = 'start_consensus',
+  restartSetup = 'restart_federation_setup',
 }
 
 export interface SetupApiInterface extends SharedApiInterface {
@@ -204,6 +205,7 @@ export interface SetupApiInterface extends SharedApiInterface {
   runDkg: () => Promise<void>;
   verifiedConfigs: () => Promise<void>;
   startConsensus: () => Promise<void>;
+  restartSetup: () => Promise<void>;
 }
 
 // Running RPC methods (only exist after run_consensus)
@@ -363,6 +365,10 @@ export class GuardianApi
     };
 
     return attemptConfirmConsensusRunning();
+  };
+
+  restartSetup: () => Promise<void> = () => {
+    return this.base.call(SetupRpc.restartSetup);
   };
 
   /*** Running RPC methods */

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -117,6 +117,10 @@
     "meta-fields-add-another": "Add another"
   },
   "setup": {
+    "common": {
+      "restart-setup": "Restart setup",
+      "restart-setup-alert": "A peer has requested to restart the setup process. This will reset any configurations you already selected for your Fedimint node"
+    },
     "progress": {
       "tos": {
         "title": "Terms of service"

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -118,8 +118,10 @@
   },
   "setup": {
     "common": {
-      "restart-setup": "Restart setup",
-      "restart-setup-alert": "A peer has requested to restart the setup process. This will reset any configurations you already selected for your Fedimint node"
+      "restart-setup": "Restart Setup",
+      "restart-setup-alert": "The Setup Leader has restarted the Setup Ceremony. Please click \"Restart\" below to continue.",
+      "confirm-restart-setup": "Are you sure you want to restart the Setup Ceremony?",
+      "confirm-restart-setup-alert": "Clicking \"Restart\" will restart the ceremony for all Guardians."
     },
     "progress": {
       "tos": {

--- a/apps/guardian-ui/src/languages/es.json
+++ b/apps/guardian-ui/src/languages/es.json
@@ -114,6 +114,10 @@
     "set-rpc-help": "Dirección RPC de Bitcoin configurada localmente"
   },
   "setup": {
+    "common": {
+      "restart-setup": "Reiniciar configuración",
+      "restart-setup-alert": "Un par ha solicitado reiniciar el proceso de configuración. Esto restablecerá cualquier configuración que ya haya seleccionado para su nodo Fedimint"
+    },
     "progress": {
       "connect-guardians": {
         "step-follower": "Confirmar información",

--- a/apps/guardian-ui/src/languages/ko.json
+++ b/apps/guardian-ui/src/languages/ko.json
@@ -114,6 +114,10 @@
     "set-rpc-help": "로컬로 구성된 비트코인 RPC 주소"
   },
   "setup": {
+    "common": {
+      "restart-setup": "설정 다시 시작",
+      "restart-setup-alert": "피어가 설정 프로세스를 다시 시작하도록 요청했습니다. 이렇게 하면 Fedimint 노드에 대해 이미 선택한 모든 구성이 재설정됩니다"
+    },
     "auth": {},
     "progress": {
       "connect-guardians": {

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -8,11 +8,11 @@ import {
   Flex,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  ModalCloseButton,
 } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
 import { useSetupContext } from '../hooks';
@@ -48,6 +48,7 @@ export const FederationSetup: React.FC = () => {
     api,
   } = useSetupContext();
   const [needsTosAgreement, setNeedsTosAgreement] = useState(!!getEnv().TOS);
+  const [confirmRestart, setConfirmRestart] = useState(false);
 
   const isHost = role === GuardianRole.Host;
   const isSolo = role === GuardianRole.Solo;
@@ -179,11 +180,11 @@ export const FederationSetup: React.FC = () => {
               {t('common.back')}
             </Button>
           )}
-          {canRestart && (
+          {canRestart && isHost && (
             <Button
               variant='link'
               colorScheme='red'
-              onClick={handleRestart}
+              onClick={() => setConfirmRestart(true)}
               rightIcon={<Icon as={CancelIcon} />}
             >
               {t('setup.common.restart-setup')}
@@ -208,10 +209,28 @@ export const FederationSetup: React.FC = () => {
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>{t('setup.common.restart-setup')}</ModalHeader>
-          <ModalCloseButton />
           <ModalBody>{t('setup.common.restart-setup-alert')}</ModalBody>
           <ModalFooter>
             <Button mr={3} onClick={handleRestart}>
+              {t('setup.common.restart-setup')}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+      <Modal isOpen={confirmRestart} onClose={() => setConfirmRestart(false)}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalCloseButton />
+          <ModalHeader>{t('setup.common.confirm-restart-setup')}</ModalHeader>
+          <ModalBody>{t('setup.common.confirm-restart-setup-alert')}</ModalBody>
+          <ModalFooter>
+            <Button
+              mr={3}
+              onClick={() => {
+                setConfirmRestart(false);
+                handleRestart();
+              }}
+            >
               {t('setup.common.restart-setup')}
             </Button>
           </ModalFooter>

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1699714741,
-        "narHash": "sha256-7cRZc3RoBv4n9GgMun+OoTK5ssI2fzqkDAZsp37uhTs=",
+        "lastModified": 1703184318,
+        "narHash": "sha256-vx2/goSpegxiFc7e1jKNHzBkhnsIQjriV4GZLaVe17M=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "3338fcfb59cea5fcd7d2a4e7fe24cbc7cb778003",
+        "rev": "a5fb72de318a74eb69a2c241c0e46705684a35d0",
         "type": "github"
       },
       "original": {
@@ -93,22 +93,24 @@
         "advisory-db": "advisory-db",
         "flake-utils": "flake-utils",
         "flakebox": "flakebox",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-kitman": "nixpkgs-kitman",
-        "nixpkgs-unstable": "nixpkgs-unstable_2"
+        "nixpkgs": [
+          "fedimint",
+          "flakebox",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1704316564,
-        "narHash": "sha256-cuAIJniPQKXfwfl2RBon5iHAaB88GUBjQ1g0IpJwipk=",
+        "lastModified": 1705299945,
+        "narHash": "sha256-80EB7qve/LeRD+kALTRibNWRokoq2Hw007I7mi0Zu7M=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "a8422b84102ab5fc768307215d5b20d807143f27",
+        "rev": "9ec5418ee002134188d4584cc645fe1b5ffba4f1",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "a8422b84102ab5fc768307215d5b20d807143f27",
+        "rev": "9ec5418ee002134188d4584cc645fe1b5ffba4f1",
         "type": "github"
       }
     },
@@ -140,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -198,11 +200,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -218,111 +220,46 @@
         "fenix": "fenix",
         "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1699681206,
-        "narHash": "sha256-vg/aDhDPV8QUi2rE3O5C/FgSaxOPZRsuRNvto5aY/JM=",
-        "owner": "rustshop",
+        "lastModified": 1703200945,
+        "narHash": "sha256-Uzf4pJaqlpRE5N+pR+YRfQcodzkYi5X1LbQLrQcPgZQ=",
+        "owner": "dpc",
         "repo": "flakebox",
-        "rev": "390c23bc911b354f16db4d925dbe9b1f795308ed",
+        "rev": "d7f57f94f2dca67dafd02b31b030b62f6fefecbc",
         "type": "github"
       },
       "original": {
-        "owner": "rustshop",
+        "owner": "dpc",
         "repo": "flakebox",
-        "rev": "390c23bc911b354f16db4d925dbe9b1f795308ed",
+        "rev": "d7f57f94f2dca67dafd02b31b030b62f6fefecbc",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699291058,
-        "narHash": "sha256-5ggduoaAMPHUy4riL+OrlAZE14Kh7JWX4oLEs22ZqfU=",
+        "lastModified": 1703992652,
+        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
+        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-kitman": {
-      "locked": {
-        "lastModified": 1677533122,
-        "narHash": "sha256-nYSQfuPruk5oAF0J7Pp3/Si3tS/H1lg4Rwi7QIbgDJ8=",
-        "owner": "jkitman",
-        "repo": "nixpkgs",
-        "rev": "61ccef8bc0a010a21ccdeb10a92220a47d8149ac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jkitman",
-        "ref": "add-esplora-pkg",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1699099776,
-        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable_2": {
-      "locked": {
-        "lastModified": 1699099776,
-        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1699596684,
-        "narHash": "sha256-XSXP8zjBZJBVvpNb2WmY0eW8O2ce+sVyj1T0/iBRIvg=",
+        "lastModified": 1705331948,
+        "narHash": "sha256-qjQXfvrAT1/RKDFAMdl8Hw3m4tLVvMCc8fMqzJv0pP4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1704420045,
-        "narHash": "sha256-C36QmoJd5tdQ5R9MC1jM7fBkZW9zBUqbUCsgwS6j4QU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c1be43e8e837b8dbee2b3665a007e761680f0c3d",
+        "rev": "b8dd8be3c790215716e7c12b247f45ca525867e2",
         "type": "github"
       },
       "original": {
@@ -336,7 +273,7 @@
       "inputs": {
         "fedimint": "fedimint",
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "rust-analyzer-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
       url =
-        "github:fedimint/fedimint?rev=a8422b84102ab5fc768307215d5b20d807143f27";
+        "github:fedimint/fedimint?rev=9ec5418ee002134188d4584cc645fe1b5ffba4f1";
     };
   };
   outputs = { self, nixpkgs, flake-utils, fedimint }:

--- a/packages/types/src/federation.ts
+++ b/packages/types/src/federation.ts
@@ -14,6 +14,7 @@ export enum ServerStatus {
   VerifyingConfigs = 'verifying_configs',
   VerifiedConfigs = 'verified_configs',
   Upgrading = 'upgrading',
+  SetupRestarted = 'setup_restarted',
   ConsensusRunning = 'consensus_running',
 }
 


### PR DESCRIPTION
Add UX for restarting federation setup. These need design review as the UX spec doesn't include restart experience

**Validations**

- [x] Lead guardian can initiate setup restart at `SetConfiguration`, `ConnectGuardians`, `RunDKG` or `VerifyGuardians` pages
- [ ] Any follower guardian can initiate setup restart at the same pages
- [x] All guardians get notified of restart intent, and have to restart before proceeding

![image](https://github.com/fedimint/ui/assets/11217077/111b2cd0-df88-455c-93e0-5409b8a1a7f3)
![image](https://github.com/fedimint/ui/assets/11217077/549bd730-b02f-401f-96f7-4585b1d62d88)

close #253 