### PR TITLE
fix: update local state for verify config hashes

### DIFF
--- a/apps/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/apps/guardian-ui/src/components/VerifyGuardians.tsx
@@ -122,10 +122,15 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
       peersWithHash.every(({ hash }, idx) => hash === enteredHashes[idx]);
 
     if (isAllValid && !verifiedConfigs) {
-      api.verifiedConfigs().catch((err) => {
-        setError(formatApiErrorMessage(err));
-      });
-      toggleConsensusPolling(false);
+      api
+        .verifiedConfigs()
+        .then(() => {
+          setVerifiedConfigs(true);
+          toggleConsensusPolling(false);
+        })
+        .catch((err) => {
+          setError(formatApiErrorMessage(err));
+        });
     }
   }, [
     api,


### PR DESCRIPTION
fixes a state bug where `toggleConsensusPolling(false) would mean `VerifyGuardians` page doesn't activate next button even after all guardians have been verified. before this fix, the user is forced to reload page to proceed