### PR TITLE
refactor: tabbed guardian dashboard

### DIFF
--- a/apps/guardian-ui/src/admin/FederationAdmin.tsx
+++ b/apps/guardian-ui/src/admin/FederationAdmin.tsx
@@ -1,16 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Flex, Box, Heading, Skeleton } from '@chakra-ui/react';
+import { Box, Flex, Heading, Skeleton } from '@chakra-ui/react';
 import {
   ClientConfig,
   ModulesConfigResponse,
   StatusResponse,
 } from '@fedimint/types';
 import { useAdminContext } from '../hooks';
-import { GatewaysCard } from '../components/GatewaysCard';
-import { GuardiansCard } from '../components/GuardiansCard';
-import { FederationInfoCard } from '../components/FederationInfoCard';
-import { BitcoinNodeCard } from '../components/BitcoinNodeCard';
-import { BalanceCard } from '../components/BalanceCard';
+import { TabsCard } from '../components/TabsCard';
 import { InviteCode } from '../components/InviteCode';
 
 export const FederationAdmin: React.FC = () => {
@@ -46,19 +42,11 @@ export const FederationAdmin: React.FC = () => {
           </Heading>
           <InviteCode inviteCode={inviteCode} />
         </Box>
-        <Flex
-          gap={6}
-          alignItems='flex-start'
-          flexDir={{ base: 'column', sm: 'column', md: 'row' }}
-        >
-          <FederationInfoCard status={status} config={config} />
-          <Flex w='100%' direction='column' gap={5}>
-            <BalanceCard />
-            <BitcoinNodeCard modulesConfigs={modulesConfigs} />
-          </Flex>
-        </Flex>
-        <GuardiansCard status={status} config={config} />
-        <GatewaysCard config={config} />
+        <TabsCard
+          status={status}
+          config={config}
+          modulesConfigs={modulesConfigs}
+        />
       </Flex>
     </Flex>
   );

--- a/apps/guardian-ui/src/components/AdminCards.tsx
+++ b/apps/guardian-ui/src/components/AdminCards.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Flex } from '@chakra-ui/react';
+import { FederationInfoCard } from './FederationInfoCard';
+import { BalanceCard } from './BalanceCard';
+import { BitcoinNodeCard } from './BitcoinNodeCard';
+import {
+  StatusResponse,
+  ClientConfig,
+  ModulesConfigResponse,
+} from '@fedimint/types';
+
+interface AdminCardProps {
+  status: StatusResponse | undefined;
+  config: ClientConfig | undefined;
+  modulesConfigs: ModulesConfigResponse | undefined;
+}
+
+export const AdminCards: React.FC<AdminCardProps> = ({
+  status,
+  config,
+  modulesConfigs,
+}) => (
+  <Flex
+    gap={6}
+    alignItems='flex-start'
+    flexDir={{ base: 'column', sm: 'column', md: 'row' }}
+  >
+    <FederationInfoCard status={status} config={config} />
+    <Flex w='100%' direction='column' gap={5}>
+      <BalanceCard />
+      <BitcoinNodeCard modulesConfigs={modulesConfigs} />
+    </Flex>
+  </Flex>
+);

--- a/apps/guardian-ui/src/components/GatewaysTable.tsx
+++ b/apps/guardian-ui/src/components/GatewaysTable.tsx
@@ -5,9 +5,6 @@ import {
   AlertIcon,
   AlertTitle,
   Box,
-  Card,
-  CardBody,
-  CardHeader,
   Flex,
   Link,
   Text,
@@ -22,11 +19,11 @@ import { ReactComponent as InfoIcon } from '../assets/svgs/info.svg';
 
 type TableKey = 'nodeId' | 'gatewayId' | 'fee';
 
-interface GatewaysCardProps {
+interface GatewaysTableProps {
   config: ClientConfig | undefined;
 }
 
-export const GatewaysCard: React.FC<GatewaysCardProps> = ({ config }) => {
+export const GatewaysTable: React.FC<GatewaysTableProps> = ({ config }) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const { api } = useAdminContext();
@@ -106,34 +103,21 @@ export const GatewaysCard: React.FC<GatewaysCardProps> = ({ config }) => {
     [gateways, t, theme]
   );
 
-  return (
-    <Card>
-      <CardHeader>
-        <Text size='lg' fontWeight='600'>
-          {t('federation-dashboard.gateways.label')}
-        </Text>
-      </CardHeader>
-      <CardBody>
-        {gateways.length === 0 ? (
-          <Flex justifyContent='center'>
-            <Alert status='info'>
-              <AlertIcon as={InfoIcon} />
-              <Box>
-                <AlertTitle>
-                  {t('federation-dashboard.gateways.no-gateways-info-title')}
-                </AlertTitle>
-                <AlertDescription>
-                  {t(
-                    'federation-dashboard.gateways.no-gateways-info-description'
-                  )}
-                </AlertDescription>
-              </Box>
-            </Alert>
-          </Flex>
-        ) : (
-          <Table columns={columns} rows={rows} />
-        )}
-      </CardBody>
-    </Card>
+  return gateways.length === 0 ? (
+    <Flex justifyContent='center'>
+      <Alert status='info'>
+        <AlertIcon as={InfoIcon} />
+        <Box>
+          <AlertTitle>
+            {t('federation-dashboard.gateways.no-gateways-info-title')}
+          </AlertTitle>
+          <AlertDescription>
+            {t('federation-dashboard.gateways.no-gateways-info-description')}
+          </AlertDescription>
+        </Box>
+      </Alert>
+    </Flex>
+  ) : (
+    <Table columns={columns} rows={rows} />
   );
 };

--- a/apps/guardian-ui/src/components/GuardiansTable.tsx
+++ b/apps/guardian-ui/src/components/GuardiansTable.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import { Card, CardBody, CardHeader, Text } from '@chakra-ui/react';
 import {
   ClientConfig,
   PeerConnectionStatus,
@@ -15,7 +14,7 @@ interface Props {
   config: ClientConfig | undefined;
 }
 
-export const GuardiansCard: React.FC<Props> = ({ status, config }) => {
+export const GuardiansTable: React.FC<Props> = ({ status, config }) => {
   const { t } = useTranslation();
 
   const columns: TableColumn<TableKey>[] = useMemo(
@@ -86,16 +85,5 @@ export const GuardiansCard: React.FC<Props> = ({ status, config }) => {
     return null;
   }
 
-  return (
-    <Card flex='1'>
-      <CardHeader>
-        <Text size='lg' fontWeight='600'>
-          {t('federation-dashboard.guardians.label')}
-        </Text>
-      </CardHeader>
-      <CardBody>
-        <Table columns={columns} rows={rows} />
-      </CardBody>
-    </Card>
-  );
+  return <Table columns={columns} rows={rows} />;
 };

--- a/apps/guardian-ui/src/components/TabsCard.tsx
+++ b/apps/guardian-ui/src/components/TabsCard.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
+import { GuardiansTable } from './GuardiansTable';
+import { GatewaysTable } from './GatewaysTable';
+import { useTranslation } from '@fedimint/utils';
+import {
+  ClientConfig,
+  ModulesConfigResponse,
+  StatusResponse,
+} from '@fedimint/types';
+import { AdminCards } from './AdminCards';
+
+interface TabsCardProps {
+  status: StatusResponse | undefined;
+  config: ClientConfig | undefined;
+  modulesConfigs: ModulesConfigResponse | undefined;
+}
+
+export const TabsCard: React.FC<TabsCardProps> = ({
+  status,
+  config,
+  modulesConfigs,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Tabs>
+      <TabList>
+        <Tab>Admin</Tab>
+        <Tab>{t('federation-dashboard.guardians.label')}</Tab>
+        <Tab>{t('federation-dashboard.gateways.label')}</Tab>
+      </TabList>
+
+      <TabPanels>
+        <TabPanel>
+          <AdminCards
+            status={status}
+            config={config}
+            modulesConfigs={modulesConfigs}
+          />
+        </TabPanel>
+        <TabPanel>
+          <GuardiansTable status={status} config={config} />
+        </TabPanel>
+        <TabPanel>
+          <GatewaysTable config={config} />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+};


### PR DESCRIPTION
Refactors to a tabbed view, I think this looks a lot better and gives me the flexibility to add in tabs for Meta Config and Propose Meta Update:

<img width="1310" alt="image" src="https://github.com/fedimint/ui/assets/74332828/5b281ba2-4850-488e-97b9-67fc72e409b4">
<img width="1285" alt="image" src="https://github.com/fedimint/ui/assets/74332828/972b6652-6fbe-47e8-a9ff-cea5be5b90c0">
