### PR TITLE
fix: disable restart if any peer is in consensus running

### DIFF
--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -43,7 +43,7 @@ const PROGRESS_ORDER: SetupProgress[] = [
 export const FederationSetup: React.FC = () => {
   const { t } = useTranslation();
   const {
-    state: { progress, role, peers },
+    state: { progress, role, peers, canRestart },
     dispatch,
     api,
   } = useSetupContext();
@@ -85,7 +85,6 @@ export const FederationSetup: React.FC = () => {
   let title: React.ReactNode;
   let subtitle: React.ReactNode;
   let canGoBack = false;
-  let canRestart = false;
   let content: React.ReactNode;
 
   switch (progress) {
@@ -120,19 +119,20 @@ export const FederationSetup: React.FC = () => {
         : t('setup.progress.connect-guardians.subtitle-follower');
       content = <ConnectGuardians next={handleNext} />;
       canGoBack = true;
-      canRestart = true;
+      dispatch({
+        type: SETUP_ACTION_TYPE.SET_CAN_RESTART,
+        payload: true,
+      });
       break;
     case SetupProgress.RunDKG:
       title = t('setup.progress.run-dkg.title');
       subtitle = t('setup.progress.run-dkg.subtitle');
       content = <RunDKG next={handleNext} />;
-      canRestart = true;
       break;
     case SetupProgress.VerifyGuardians:
       title = t('setup.progress.verify-guardians.title');
       subtitle = t('setup.progress.verify-guardians.subtitle');
       content = <VerifyGuardians next={handleNext} />;
-      canRestart = true;
       break;
     case SetupProgress.SetupComplete:
       content = <SetupComplete />;

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -68,6 +68,7 @@ export interface SetupState {
   configGenParams: ConfigGenParams | null;
   numPeers: number;
   peers: Peer[];
+  canRestart: boolean;
 }
 
 export enum SETUP_ACTION_TYPE {
@@ -81,6 +82,7 @@ export enum SETUP_ACTION_TYPE {
   SET_PEERS = 'SET_PEERS',
   SET_IS_SETUP_COMPLETE = 'SET_IS_SETUP_COMPLETE',
   SET_OUR_CURRENT_ID = 'SET_OUR_CURRENT_ID',
+  SET_CAN_RESTART = 'SET_CAN_RESTART',
 }
 
 export type SetupAction =
@@ -123,6 +125,10 @@ export type SetupAction =
   | {
       type: SETUP_ACTION_TYPE.SET_OUR_CURRENT_ID;
       payload: number;
+    }
+  | {
+      type: SETUP_ACTION_TYPE.SET_CAN_RESTART;
+      payload: boolean;
     };
 
 // Setup RPC methods (only exist during setup)


### PR DESCRIPTION
fix #358 

for this to work, we need to update upstream so that whenever a guardian is transitioning to consensus running, they inform the leader of this state change so their last known status from leader setup api becomes `consensus_running` rather than `verified_configs`