### PR TITLE
feat: allow browser language detection

### DIFF
--- a/packages/utils/src/i18n.tsx
+++ b/packages/utils/src/i18n.tsx
@@ -16,9 +16,15 @@ export const i18nProvider = (namespace: Language[]) => {
     {}
   );
 
-  i18n.use(LanguageDetector).use(initReactI18next).init({
-    debug: true,
-    resources,
-    fallbackLng: 'en-US',
-  });
+  i18n
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
+      debug: true,
+      resources,
+      fallbackLng: 'en-US',
+      detection: {
+        caches: [],
+      },
+    });
 };


### PR DESCRIPTION
Resolves #350 

This PR allows i18next to detect the language set in the user's browser and translate the page.

Translation happens seamlessly now.