### PR TITLE
Fix gateway api auth

### DIFF
--- a/apps/gateway-ui/src/GatewayApi.ts
+++ b/apps/gateway-ui/src/GatewayApi.ts
@@ -6,12 +6,9 @@ const SESSION_STORAGE_KEY = 'gateway-ui-key';
 export class GatewayApi {
   private baseUrl: string | undefined = process.env.REACT_APP_FM_GATEWAY_API;
 
-  // Tests a provided password, or the one in the environment config, or the one in session storage
+  // Tests a provided password or the one in session storage
   testPassword = async (password?: string): Promise<boolean> => {
-    const tempPassword =
-      password ||
-      this.getPassword() ||
-      process.env.REACT_APP_FM_GATEWAY_PASSWORD;
+    const tempPassword = password || this.getPassword();
 
     if (!tempPassword) {
       return false;


### PR DESCRIPTION
If you set the Gateway API in the server side environment variables it'll set it as authed for any client logging in. Removes pull from env for gateway api test password.