### PR TITLE
feat: pass in query param for role

### DIFF
--- a/apps/guardian-ui/src/components/RoleSelector.tsx
+++ b/apps/guardian-ui/src/components/RoleSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Button,
   Icon,
@@ -30,6 +30,26 @@ export const RoleSelector = React.memo<Props>(function RoleSelector({
   const { t } = useTranslation();
   const { dispatch } = useSetupContext();
   const [role, setRole] = useState<GuardianRole>();
+
+  // If role in query params, set it
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const role = urlParams.get('role')?.toLowerCase();
+    if (role) {
+      switch (role) {
+        case 'host':
+          setRole(GuardianRole.Host);
+          break;
+        case 'follower':
+          setRole(GuardianRole.Follower);
+          break;
+        case 'solo':
+          setRole(GuardianRole.Solo);
+          break;
+      }
+    }
+  }, []);
+
   const options: RadioButtonOption<GuardianRole>[] = useMemo(
     () => [
       {


### PR DESCRIPTION
Lets you pass in `role` as a query param so we can skip the first setup page, we've found it a hiccup when doing setups for fedi