### PR TITLE
fix: set numPeers correctly

### DIFF
--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -41,6 +41,8 @@ interface Props {
   next: () => void;
 }
 
+const MIN_BFT_NUM_PEERS = '4';
+
 export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
   const { t } = useTranslation();
   const {
@@ -62,9 +64,6 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [hostServerUrl, setHostServerUrl] = useState('');
   const [defaultParams, setDefaultParams] = useState<ConfigGenParams>();
-  const [numPeers, setNumPeers] = useState(
-    isSolo ? '1' : stateNumPeers ? stateNumPeers.toString() : '4'
-  );
   const [federationName, setFederationName] = useState('');
   const [metaFields, setMetaFields] = useState<[string, string][]>([['', '']]);
   const [blockConfirmations, setBlockConfirmations] = useState('');
@@ -75,6 +74,9 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
   });
   const [mintAmounts, setMintAmounts] = useState<number[]>([]);
   const [error, setError] = useState<string>();
+  const [numPeers, setNumPeers] = useState(
+    stateNumPeers ? stateNumPeers.toString() : isSolo ? '1' : MIN_BFT_NUM_PEERS
+  );
 
   useEffect(() => {
     const initStateFromParams = (params: ConfigGenParams) => {

--- a/apps/guardian-ui/src/setup/SetupContext.tsx
+++ b/apps/guardian-ui/src/setup/SetupContext.tsx
@@ -23,19 +23,7 @@ const LOCAL_STORAGE_SETUP_KEY = 'setup-guardian-ui-state';
  * Creates the initial state using loaded state from local storage.
  */
 function makeInitialState(loadFromStorage = true): SetupState {
-  let storageState: Partial<SetupState> = {};
-  if (loadFromStorage) {
-    try {
-      const storageJson = localStorage.getItem(LOCAL_STORAGE_SETUP_KEY);
-      if (storageJson) {
-        storageState = JSON.parse(storageJson);
-      }
-    } catch (err) {
-      console.warn('Encountered error while fetching storage state', err);
-    }
-  }
-
-  const initialState = {
+  let state: SetupState = {
     role: null,
     progress: SetupProgress.Start,
     myName: '',
@@ -44,20 +32,29 @@ function makeInitialState(loadFromStorage = true): SetupState {
     numPeers: 0,
     peers: [],
     ourCurrentId: null,
-    ...storageState,
   };
-
-  if (
-    initialState.progress !== SetupProgress.Start &&
-    initialState.configGenParams !== null &&
-    isConsensusparams(initialState.configGenParams)
-  ) {
-    const peers = Object.values(initialState.configGenParams.peers);
-    initialState.peers = peers;
-    initialState.numPeers = peers.length;
+  if (loadFromStorage) {
+    try {
+      const storageJson = localStorage.getItem(LOCAL_STORAGE_SETUP_KEY);
+      if (storageJson) {
+        state = JSON.parse(storageJson) as SetupState;
+      }
+    } catch (err) {
+      console.warn('Encountered error while fetching storage state', err);
+    }
   }
 
-  return initialState;
+  if (
+    state.progress !== SetupProgress.Start &&
+    state.configGenParams !== null &&
+    isConsensusparams(state.configGenParams)
+  ) {
+    const peers = Object.values(state.configGenParams.peers);
+    state.peers = peers;
+    state.numPeers = state.numPeers ? state.numPeers : peers.length;
+  }
+
+  return state;
 }
 
 const initialState = makeInitialState();


### PR DESCRIPTION
fixes https://github.com/fedimint/ui/issues/385

We weren't properly loading the state from localStorage, and we were setting numPeers from connected Peers not from stateNumPeers. This lets the setup leader refresh and maintain state and connections to peers, and doesn't kick to DKG immediately on refresh.