### PR TITLE
feat: define logic to autogenerate guardian password

### DIFF
--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
-  useClipboard,
+  Checkbox,
   Flex,
   FormControl,
   FormLabel,
@@ -11,6 +11,7 @@ import {
   Button,
   Text,
   useTheme,
+  useClipboard,
 } from '@chakra-ui/react';
 import {
   BitcoinRpc,
@@ -60,6 +61,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
   const isSolo = role === GuardianRole.Solo;
   const [myName, setMyName] = useState(stateMyName);
   const [password, setPassword] = useState(statePassword);
+  const [passwordCheck, setPasswordCheck] = useState(Boolean);
   const [hostServerUrl, setHostServerUrl] = useState('');
   const [defaultParams, setDefaultParams] = useState<ConfigGenParams>();
   const [federationName, setFederationName] = useState('');
@@ -124,6 +126,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
     ? Boolean(
         myName &&
           password &&
+          passwordCheck &&
           federationName &&
           isValidNumber(numPeers, 4) &&
           isValidNumber(blockConfirmations, 1, 200) &&
@@ -134,6 +137,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
     ? Boolean(
         myName &&
           password &&
+          passwordCheck &&
           federationName &&
           isValidNumber(blockConfirmations, 1, 200) &&
           isValidMeta(metaFields) &&
@@ -251,25 +255,33 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
         </FormControl>
         <FormControl>
           <FormLabel>{t('set-config.admin-password')}</FormLabel>
-          <Button onClick={generatePassword} mb={2} w='100%'>
-            Generate Password
-          </Button>
           <Flex gap={2}>
             <Input
               type='text'
               value={password}
               readOnly
-              w='75%'
+              w='80%'
               placeholder='Password'
             />
-            <Button onClick={onCopy} w='22%'>
+            <Button onClick={onCopy} w='20%'>
               {hasCopied ? 'Copied!' : 'Copy'}
             </Button>
           </Flex>
-          <FormHelperText>
-            <Text color={theme.colors.yellow[500]}>
-              {t('set-config.admin-password-help')}
-            </Text>
+          <FormControl>
+            <Button onClick={generatePassword} mt={2} w='100%'>
+              Generate Password
+            </Button>
+          </FormControl>
+          <FormHelperText style={{ marginTop: '16px', marginBottom: '16px' }}>
+            <Checkbox
+              isRequired
+              spacing='10px'
+              onChange={(e) => setPasswordCheck(e.target.checked)}
+            >
+              <Text color={theme.colors.yellow[500]}>
+                {t('set-config.admin-password-help')}
+              </Text>
+            </Checkbox>
           </FormHelperText>
         </FormControl>
         {!isHost && !isSolo && (

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -98,7 +98,7 @@
     "guardian-name": "Guardian name",
     "guardian-name-help": "This name will be shown to other Guardians",
     "admin-password": "Admin password",
-    "admin-password-help": "Please back up your password! Password recovery is not available!",
+    "admin-password-help": "By checking this box, you acknowledge that you have copied and securely saved the password in a location only accessible to you. This ensures the safety and confidentiality of your Federation.",
     "confirm-password": "Confirm password",
     "error-password-mismatch": "Passwords don't match",
     "join-federation": "Join Federation link",

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -98,7 +98,7 @@
     "guardian-name": "Guardian name",
     "guardian-name-help": "This name will be shown to other Guardians",
     "admin-password": "Admin password",
-    "admin-password-help": "Use a strong password & back it up! You cannot recover this password!",
+    "admin-password-help": "Please back up your password! Password recovery is not available!",
     "confirm-password": "Confirm password",
     "error-password-mismatch": "Passwords don't match",
     "join-federation": "Join Federation link",


### PR DESCRIPTION
Addresses #393 

This logic generates a 16-character password that guardians can copy and backup and present during password check.

Question: At what point should password check happen? 

**Updated user flow**:
![image](https://github.com/fedimint/ui/assets/41724425/289d1fd6-c643-45b5-9427-0bc4a5334c30)


[Screencast from 02-04-2024 10:41:39 ASUBUHI.webm](https://github.com/fedimint/ui/assets/41724425/143120c3-2d68-40e1-a727-c5b1f90e321b)
