### PR TITLE
chore: update ClientConfig type

### DIFF
--- a/packages/types/src/federation.ts
+++ b/packages/types/src/federation.ts
@@ -88,8 +88,6 @@ export type ModuleApiVersion = MajorAndMinorVersions;
 
 export interface ClientConfig {
   consensus_version: CoreConsensusVersion;
-  epoch_pk: string;
-  federation_id: string;
   api_endpoints: Record<number, ApiEndpoint>;
   modules: Record<number, FedimintModule>;
   meta: MetaConfig;


### PR DESCRIPTION
Removes old fields that are no-longer present in type returned by FM API

closes #390 