### PR TITLE
feat: api for fetching federation id

### DIFF
--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -233,6 +233,10 @@ export class GuardianApi {
     return this.call(AdminRpc.federationStatus);
   };
 
+  public federationId = (): Promise<string> => {
+    return this.call(AdminRpc.federationId);
+  };
+
   public inviteCode = (): Promise<string> => {
     return this.call(AdminRpc.inviteCode);
   };

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -149,6 +149,7 @@ export enum AdminRpc {
   moduleApiCall = 'module',
   audit = 'audit',
   downloadGuardianBackup = 'download_guardian_backup',
+  federationId = 'federation_id',
 }
 
 export enum SharedRpc {


### PR DESCRIPTION
adds `GuardianApi` method for fetching federation id. Enabled by https://github.com/fedimint/fedimint/pull/4576