### PR TITLE
chore: reference target-nix when using local FM

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Cargo build directory.
 /target
+/target-nix
 
 # Nix build directory.
 /result

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,10 @@ yarn-error.log*
 .turbo
 
 /target/
+/target-nix/
 # in case it's a symlink
 /target
+/target-nix
 
 /result
 .idea

--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ The docker containers and devimint are for specific releases or commits of `fedi
 If you would like to run the UIs against a particular version of fedimint, or using changes you have made locally to fedimint itself:
 
 1. Run `cargo build` in fedimint
-2. Run `env DEVIMINT_BIN=$(realpath ../fedimint/target/debug) yarn nix-guardian` (assuming that you have `ui` and `fedimint` repos checked out in the same directory)
+2. Run `env DEVIMINT_BIN=$(realpath ../fedimint/target-nix/debug) yarn nix-guardian` (assuming that you have `ui` and `fedimint` repos checked out in the same directory)
 
-This will put binaries in `fedimint/target/debug` at the front of your `$PATH`. Devimint will use these binaries instead of the ones installed via Nix.
+This will put binaries in `fedimint/target-nix/debug` at the front of your `$PATH`. Devimint will use these binaries instead of the ones installed via Nix.
 
 ### Bumping referenced Fedimint
 

--- a/scripts/mprocs-nix.sh
+++ b/scripts/mprocs-nix.sh
@@ -17,7 +17,7 @@ mkdir $FM_TEST_DIR
 mkdir $FM_LOGS_DIR
 touch $FM_PID_FILE
 
-# Flag to have devimint use binaries in specific folder, e.g. "../fedimint/target/debug"
+# Flag to have devimint use binaries in specific folder, e.g. "../fedimint/target-nix/debug"
 if [ -n DEVIMINT_BIN ]; then
   export PATH=$DEVIMINT_BIN:$PATH
 fi


### PR DESCRIPTION
https://github.com/fedimint/fedimint/pull/4470 moved dev shell outputs to `./target-nix`. This PR updates the UI docs for the same