### PR TITLE
fix: required config gen local and consensus + fix password runtime error

### DIFF
--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -31,7 +31,6 @@ import {
   formatApiErrorMessage,
   getModuleParamsFromConfig,
   applyConfigGenModuleParams,
-  removeConfigGenModuleConsensusParams,
 } from '../utils/api';
 import { isValidMeta, isValidNumber } from '../utils/validators';
 import { NumberFormControl } from './NumberFormControl';
@@ -210,7 +209,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
           configs: {
             hostServerUrl,
             meta: {},
-            modules: removeConfigGenModuleConsensusParams(moduleConfigs),
+            modules: moduleConfigs,
           },
         });
       }
@@ -250,7 +249,9 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
           </FormHelperText>
         </FormControl>
         <FormControl
-          isInvalid={password !== confirmPassword && password.length > 0}
+          isInvalid={
+            !!password && password !== confirmPassword && password.length > 0
+          }
         >
           <FormLabel>{t('set-config.confirm-password')}</FormLabel>
           <Input
@@ -259,7 +260,8 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
             onChange={(ev) => setConfirmPassword(ev.currentTarget.value)}
           />
           <FormErrorMessage>
-            {password !== confirmPassword &&
+            {!!password &&
+              password !== confirmPassword &&
               password.length > 0 &&
               t('set-config.error-password-mismatch')}
           </FormErrorMessage>

--- a/apps/guardian-ui/src/setup/SetupContext.tsx
+++ b/apps/guardian-ui/src/setup/SetupContext.tsx
@@ -285,6 +285,7 @@ export const SetupContextProvider: React.FC<SetupContextProviderProps> = ({
           // Followers set their own connection name, and hosts server URL to connect to.
           await api.setConfigGenConnections(myName, configs.hostServerUrl);
 
+          console.log('configs', configs);
           // Followers submit ONLY their local config gen params.
           await api.setConfigGenParams(configs);
 

--- a/apps/guardian-ui/src/utils/api.ts
+++ b/apps/guardian-ui/src/utils/api.ts
@@ -47,19 +47,6 @@ export function applyConfigGenModuleParams(
 }
 
 /**
- * Filter out consensus module config gen params to only have local ones.
- */
-export function removeConfigGenModuleConsensusParams(
-  moduleParams: ConfigGenParams['modules']
-): ConfigGenParams['modules'] {
-  const newParams = { ...moduleParams };
-  Object.values(newParams).forEach((module) => {
-    module[1] = { local: module[1].local };
-  });
-  return newParams;
-}
-
-/**
  * Given a config, filter out all non-default modules
  */
 export function getOtherModuleParamsFromConfig(

--- a/packages/types/src/modules.ts
+++ b/packages/types/src/modules.ts
@@ -57,34 +57,31 @@ export type ModuleConfig<T extends ModuleKind = ModuleKind> = {
 export type LnModuleParams = [
   ModuleKind.Ln,
   {
-    consensus?: object;
-    local?: object;
+    consensus: object;
+    local: object;
   }
 ];
 export type MintModuleParams = [
   ModuleKind.Mint,
   {
-    consensus?: { mint_amounts: number[] };
-    local?: object;
+    consensus: { mint_amounts: number[] };
+    local: object;
   }
 ];
 export type WalletModuleParams = [
   ModuleKind.Wallet,
   {
-    consensus?: {
+    consensus: {
       finality_delay: number;
       network: Network;
       client_default_bitcoin_rpc: BitcoinRpc;
     };
-    local?: {
+    local: {
       bitcoin_rpc: BitcoinRpc;
     };
   }
 ];
-export type OtherModuleParams = [
-  string,
-  { consensus?: object; local?: object }
-];
+export type OtherModuleParams = [string, { consensus: object; local: object }];
 export type AnyModuleParams =
   | LnModuleParams
   | MintModuleParams


### PR DESCRIPTION
Fixes https://github.com/fedimint/ui/issues/397

Consensus and Local are now required for submitting module params in setup so we don't filter them out anymore for the follower, plus me and eric ran into a runtime issue where the password was nulled on refresh that this fixes by doing a !!password check