### PR TITLE
Random Guardian Names

### DIFF
--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -96,7 +96,8 @@
   },
   "set-config": {
     "guardian-name": "Guardian name",
-    "guardian-name-help": "This name will be shown to other Guardians",
+    "guardian-name-help": "This random name will be shown to other Guardians",
+    "generate-random-name": "Generate random guardian name",
     "admin-password": "Admin password",
     "admin-password-help": "Use a strong password & back it up! You cannot recover this password!",
     "confirm-password": "Confirm password",

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -97,7 +97,6 @@
   "set-config": {
     "guardian-name": "Guardian name",
     "guardian-name-help": "This random name will be shown to other Guardians",
-    "generate-random-name": "Generate random guardian name",
     "admin-password": "Admin password",
     "admin-password-help": "Use a strong password & back it up! You cannot recover this password!",
     "confirm-password": "Confirm password",

--- a/apps/guardian-ui/src/setup/SetupContext.tsx
+++ b/apps/guardian-ui/src/setup/SetupContext.tsx
@@ -23,10 +23,44 @@ const LOCAL_STORAGE_SETUP_KEY = 'setup-guardian-ui-state';
  * Creates the initial state using loaded state from local storage.
  */
 function makeInitialState(loadFromStorage = true): SetupState {
+  const randomNames = [
+    'Alice',
+    'Bob',
+    'Charlie',
+    'David',
+    'Eve',
+    'Frank',
+    'Grace',
+    'Harry',
+    'Iris',
+    'Jack',
+    'John',
+    'Kim',
+    'Lisa',
+    'Maggie',
+    'Mike',
+    'Naomi',
+    'Olivia',
+    'Paul',
+    'Queen',
+    'Robert',
+    'Sarah',
+    'Taylor',
+    'Victoria',
+    'William',
+    'Xavier',
+    'Yvonne',
+    'Zoe',
+  ];
+  const randomName =
+    randomNames[Math.floor(Math.random() * randomNames.length)] +
+    Math.floor(Math.random() * 100)
+      .toString()
+      .padStart(2, '0');
   let state: SetupState = {
     role: null,
     progress: SetupProgress.Start,
-    myName: '',
+    myName: randomName,
     configGenParams: null,
     password: '',
     numPeers: 0,


### PR DESCRIPTION
This just sets a random guardian name for the user instead of letting them pick one. 

Until we have something like a nostr login where you can testify to being a guardian the names here are useless and cause a bunch of headaches during setup if users don't want to correlate that they're also guardians.