### PR TITLE
feat: waiting on guardians instead of placeholders

### DIFF
--- a/apps/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/apps/guardian-ui/src/components/ConnectGuardians.tsx
@@ -174,7 +174,7 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
           }
         : {
             key: i,
-            name: `Guardian ${i + 1}`,
+            name: t('connect-guardians.waiting-for-guardian') + ` ${i + 1}...`,
             status: (
               <Tag colorScheme='gray'>{t('connect-guardians.not-joined')}</Tag>
             ),

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -14,6 +14,7 @@
     "approved": "Approved",
     "pending": "Pending",
     "not-joined": "Not joined",
+    "waiting-for-guardian": "Waiting for guardian",
     "table-title": "Federation Guardians",
     "table-description": "Guardians will be confirmed here once they confirm Federation settings.",
     "meta-field-key": "Meta field - {{key}}"


### PR DESCRIPTION
Changes the placeholder to clarify that you're waiting for them, had some feedback that it looked like Guardian 2 etc were already supposed to be connected by naming them that 
![image](https://github.com/fedimint/ui/assets/74332828/c81e547d-26b9-4596-aa04-c8428512263d)
