### PR TITLE
Config json reboot cleanup

### DIFF
--- a/Dockerfile.guardian-ui
+++ b/Dockerfile.guardian-ui
@@ -24,10 +24,7 @@ RUN yarn install
 COPY --from=builder /app/out/full/ .
 # TODO: Remove this copy once https://github.com/vercel/turbo/issues/3758 is fixed
 COPY ./turbo.json .
-RUN REACT_APP_FM_CONFIG_API="{{REACT_APP_FM_CONFIG_API}}" \
-  REACT_APP_TOS="{{REACT_APP_TOS}}" \
-  yarn build:guardian-ui
-
+RUN yarn build:guardian-ui
 
 # Run the built app with a minimal image
 FROM base AS runner
@@ -35,5 +32,6 @@ WORKDIR /app
 
 COPY --from=installer /app/apps/guardian-ui/build build
 COPY scripts/replace-react-env.js scripts/replace-react-env.js
+COPY scripts/write-config-from-env.js scripts/write-config-from-env.js
 RUN yarn global add serve
-CMD node scripts/replace-react-env.js build && serve -s build
+CMD node scripts/write-config-from-env.js build && serve -s build

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ PORT=3000 REACT_APP_FM_CONFIG_API="[app-address-here]" yarn build && yarn start
 
 Replace `PORT` with a port of your choice, and `REACT_APP_FM_CONFIG_API` with the socket address of your deployed fedimintd server.
 
+> **NOTE**: The Guardian UI references a `config.json` specified at the root of where the UI is served from. The Dockerfile writes this file from ENV VARs but a static site deployment will want to customize this file.
+
 #### Gateway UI
 
 ```bash

--- a/apps/guardian-ui/public/config.json.example
+++ b/apps/guardian-ui/public/config.json.example
@@ -1,0 +1,4 @@
+{
+    "fm_config_api": "ws://127.0.0.1:18174",
+    "tos": "terms of service go here"
+}

--- a/apps/guardian-ui/src/GuardianApi.ts
+++ b/apps/guardian-ui/src/GuardianApi.ts
@@ -13,14 +13,37 @@ import {
   StatusResponse,
   Versions,
 } from '@fedimint/types';
-import { getEnv } from './utils/env';
 import { AdminRpc, ModuleRpc, SetupRpc, SharedRpc } from './types';
 
 const SESSION_STORAGE_KEY = 'guardian-ui-key';
 
+export type GuardianConfig = {
+  fm_config_api?: string;
+  tos?: string;
+};
+
 export class GuardianApi {
   private websocket: JsonRpcWebsocket | null = null;
   private connectPromise: Promise<JsonRpcWebsocket> | null = null;
+  private guardianConfig: GuardianConfig | null = null;
+
+  public getGuardianConfig = async (): Promise<GuardianConfig> => {
+    if (this.guardianConfig === null) {
+      const response = await fetch('/config.json');
+      if (!response.ok) {
+        throw new Error('Could not find config.json');
+      }
+      const config: GuardianConfig = await response.json();
+      if (
+        config.fm_config_api === 'config api not set' ||
+        !config.fm_config_api
+      ) {
+        throw new Error('Config API not set in config.json');
+      }
+      this.guardianConfig = config;
+    }
+    return this.guardianConfig;
+  };
 
   /*** WebSocket methods ***/
 
@@ -31,14 +54,12 @@ export class GuardianApi {
     if (this.connectPromise) {
       return await this.connectPromise;
     }
+    const websocketUrl = (await this.getGuardianConfig()).fm_config_api;
+    if (!websocketUrl) {
+      throw new Error('fm_config_api not found in config.json');
+    }
 
     this.connectPromise = new Promise((resolve, reject) => {
-      const websocketUrl = getEnv().FM_CONFIG_API;
-
-      if (!websocketUrl) {
-        throw new Error('REACT_APP_FM_CONFIG_API not set');
-      }
-
       const requestTimeoutMs = 1000 * 60 * 60 * 5; // 5 minutes, dkg can take a while
       const websocket = new JsonRpcWebsocket(
         websocketUrl,

--- a/apps/guardian-ui/src/components/TermsOfService.tsx
+++ b/apps/guardian-ui/src/components/TermsOfService.tsx
@@ -1,15 +1,14 @@
 import React, { useEffect } from 'react';
 import { Button, Flex, Textarea } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
-import { getEnv } from '../utils/env';
 
 interface Props {
   next(): void;
+  tos?: string;
 }
 
-export const TermsOfService: React.FC<Props> = ({ next }) => {
+export const TermsOfService: React.FC<Props> = ({ next, tos }) => {
   const { t } = useTranslation();
-  const tos = getEnv().TOS;
 
   // If this was mistakenly rendered with no ToS, just instantly agree and continue.
   useEffect(() => {

--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -108,7 +108,7 @@ export const FederationSetup: React.FC = () => {
 
   switch (progress) {
     case SetupProgress.Start:
-      if (tosConfig.showTos) {
+      if (tosConfig?.showTos) {
         title = t('setup.progress.tos.title');
         content = (
           <TermsOfService

--- a/apps/guardian-ui/src/setup/SetupContext.tsx
+++ b/apps/guardian-ui/src/setup/SetupContext.tsx
@@ -65,6 +65,7 @@ function makeInitialState(loadFromStorage = true): SetupState {
     password: '',
     numPeers: 0,
     peers: [],
+    tosConfig: { showTos: false, tos: undefined },
     ourCurrentId: null,
   };
   if (loadFromStorage) {
@@ -113,6 +114,8 @@ const reducer = (state: SetupState, action: SetupAction): SetupState => {
       return { ...state, peers: action.payload };
     case SETUP_ACTION_TYPE.SET_OUR_CURRENT_ID:
       return { ...state, ourCurrentId: action.payload };
+    case SETUP_ACTION_TYPE.SET_TOS_CONFIG:
+      return { ...state, tosConfig: action.payload };
     default:
       return state;
   }

--- a/apps/guardian-ui/src/setupProxy.js
+++ b/apps/guardian-ui/src/setupProxy.js
@@ -1,0 +1,8 @@
+module.exports = function (app) {
+  app.use('/config.json', (_req, res) => {
+    res.json({
+      fm_config_api: process.env.REACT_APP_FM_CONFIG_API,
+      tos: process.env.REACT_APP_TOS,
+    });
+  });
+};

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -59,6 +59,11 @@ export enum StepState {
   Completed = 'Completed',
 }
 
+export interface tosConfigState {
+  showTos: boolean;
+  tos: string | undefined;
+}
+
 export interface SetupState {
   role: GuardianRole | null;
   progress: SetupProgress;
@@ -68,6 +73,7 @@ export interface SetupState {
   configGenParams: ConfigGenParams | null;
   numPeers: number;
   peers: Peer[];
+  tosConfig: tosConfigState;
 }
 
 export enum SETUP_ACTION_TYPE {
@@ -81,6 +87,7 @@ export enum SETUP_ACTION_TYPE {
   SET_PEERS = 'SET_PEERS',
   SET_IS_SETUP_COMPLETE = 'SET_IS_SETUP_COMPLETE',
   SET_OUR_CURRENT_ID = 'SET_OUR_CURRENT_ID',
+  SET_TOS_CONFIG = 'SET_TOS_CONFIG',
 }
 
 export type SetupAction =
@@ -119,6 +126,10 @@ export type SetupAction =
   | {
       type: SETUP_ACTION_TYPE.SET_IS_SETUP_COMPLETE;
       payload: boolean;
+    }
+  | {
+      type: SETUP_ACTION_TYPE.SET_TOS_CONFIG;
+      payload: tosConfigState;
     }
   | {
       type: SETUP_ACTION_TYPE.SET_OUR_CURRENT_ID;

--- a/apps/guardian-ui/src/utils/env.ts
+++ b/apps/guardian-ui/src/utils/env.ts
@@ -1,15 +1,13 @@
-export function getEnv() {
-  // This is a hack to get around react-scripts inlining environment variable
-  // checks. Boolean conditionals get reduced to `!0` and `!1` which breaks
-  // environment variable replacements from `replace-react-env.js`.
-  // Note that if you actually WANT that inlining, you should use `process.env`
-  // directly in your code, NOT `getEnv()`
-  // See https://create-react-app.dev/docs/adding-custom-environment-variables/ for more info
-  // See https://github.com/fedimint/ui/issues/224 for the long-term fix for configuration
-  return JSON.parse(
-    JSON.stringify({
-      FM_CONFIG_API: process.env.REACT_APP_FM_CONFIG_API,
-      TOS: process.env.REACT_APP_TOS,
-    })
-  );
+import { GuardianConfig } from '../GuardianApi';
+
+export async function getEnv() {
+  const response = await fetch('config.json');
+  if (!response.ok) {
+    throw new Error('Could not find config.json');
+  }
+  const config: GuardianConfig = await response.json();
+  if (config.fm_config_api === 'config api not set' || !config.fm_config_api) {
+    throw new Error('Config API not set in config.json');
+  }
+  return config;
 }

--- a/scripts/write-config-from-env.js
+++ b/scripts/write-config-from-env.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+
+const targetDir = process.argv[2];
+
+if (!targetDir) {
+  console.log('Please provide a directory path.');
+  process.exit(1);
+}
+
+function write_config(filePath) {
+  let config = {
+    fm_config_api: process.env.REACT_APP_FM_CONFIG_API,
+    tos: process.env.REACT_APP_TOS,
+  };
+
+  fs.writeFileSync(
+    filePath + '/config.json',
+    JSON.stringify(config, null, 2),
+    'utf8'
+  );
+}
+
+try {
+  write_config(targetDir);
+  console.log('Environment variables replaced successfully.');
+} catch (error) {
+  console.error(
+    'An error occurred while writing config.json from environment variables:',
+    error
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
closes remaining todos on #369 namely:

[ ] - EnvVars type defined in two spots
[ ] - move config state into it's own context

merge conflicts were encountered when comparing changes and fixed locally.


@Kodylow please take a look and see if I'm on track 