### PR TITLE
chore: update Readme instructions for mprocs setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ nix-guardian spins up these instances
 ### Option 2 - Running with mprocs
 
 1. Install [mprocs](https://github.com/pvolok/mprocs)
+1. In terminal `cd` to the fedimint-ui repo root directory and run `yarn install`
 1. Run `yarn mprocs`
 
 After running this command, you'll be present with the mprocs display. Along the left side are the list of processes currently available by mprocs. Along the bottom are hotkeys for navigating/interacting with mprocs. The main pane shows the shell output for the currently selected process.


### PR DESCRIPTION
The setup instructions for running fedmint UI in development mode using mprocs do not include the instruction to run 'yarn install'


The readme was updated to to include that step 