### PR TITLE
fix: generate password fixes

### DIFF
--- a/apps/gateway-ui/src/languages/en.json
+++ b/apps/gateway-ui/src/languages/en.json
@@ -5,9 +5,10 @@
     "bitcoin": "Bitcoin",
     "btc": "BTC",
     "confirm": "Confirm",
-    "copied": "Copied",
     "error": "Error",
-    "sats": "sats"
+    "sats": "sats",
+    "copy": "Copy",
+    "copied": "Copied!"
   },
   "admin": {
     "fetch-info-modal-text": "Checking federation details..."

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -255,33 +255,29 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
         </FormControl>
         <FormControl>
           <FormLabel>{t('set-config.admin-password')}</FormLabel>
-          <Flex gap={2}>
-            <Input
-              type='text'
-              value={password}
-              readOnly
-              w='80%'
-              placeholder='Password'
-            />
-            <Button onClick={onCopy} w='20%'>
-              {hasCopied ? 'Copied!' : 'Copy'}
+          {password ? (
+            <Flex gap={2}>
+              <Input
+                type='text'
+                value={password}
+                w='80%'
+                placeholder='Password'
+              />
+              <Button onClick={onCopy} w='20%'>
+                {hasCopied ? t('common.copied') : t('common.copy')}
+              </Button>
+            </Flex>
+          ) : (
+            <Button onClick={generatePassword} w='100%'>
+              {t('set-config.admin-password-generate')}
             </Button>
-          </Flex>
-          <FormControl>
-            <Button onClick={generatePassword} mt={2} w='100%'>
-              Generate Password
-            </Button>
-          </FormControl>
+          )}
           <FormHelperText style={{ marginTop: '16px', marginBottom: '16px' }}>
-            <Checkbox
-              isRequired
-              spacing='10px'
-              onChange={(e) => setPasswordCheck(e.target.checked)}
-            >
-              <Text color={theme.colors.yellow[500]}>
-                {t('set-config.admin-password-help')}
-              </Text>
-            </Checkbox>
+            <Text color={theme.colors.yellow[500]}>
+              {password
+                ? t('set-config.admin-password-help')
+                : t('set-config.admin-password-set')}
+            </Text>
           </FormHelperText>
         </FormControl>
         {!isHost && !isSolo && (
@@ -400,19 +396,28 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
           </Text>
         )}
         <Flex
-          direction='row'
+          direction='column'
           justify='space-between'
           alignSelf='center'
           width={['100%', '100%', '60%']}
         >
+          <Checkbox
+            isRequired
+            spacing='10px'
+            alignSelf='flex-start'
+            onChange={(e) => setPasswordCheck(e.target.checked)}
+          >
+            <Text color={theme.colors.yellow[500]}>
+              {t('set-config.admin-password-backup')}
+            </Text>
+          </Checkbox>
           <Button
             isDisabled={!isValid}
             onClick={isValid ? handleNext : undefined}
             leftIcon={<Icon as={ArrowRightIcon} />}
-            justifySelf='center'
-            alignSelf='center'
             mt={['2', '4']}
-            width={['100%', 'auto']}
+            width={['25%', 'auto']}
+            alignSelf='flex-start'
           >
             {t('common.next')}
           </Button>

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -5,7 +5,9 @@
     "back": "Back",
     "error": "Something went wrong.",
     "unknown": "Unknown",
-    "remove": "Remove"
+    "remove": "Remove",
+    "copy": "Copy",
+    "copied": "Copied!"
   },
   "connect-guardians": {
     "invite-guardians": "Invite Followers",
@@ -109,7 +111,10 @@
     "guardian-name": "Guardian name",
     "guardian-name-help": "This random name will be shown to other Guardians",
     "admin-password": "Admin password",
-    "admin-password-help": "Use a strong password & back it up! You cannot recover this password!",
+    "admin-password-generate": "Generate",
+    "admin-password-set": "Click 'Generate' to create a secure password. You can modify it, but this password must be secure and backed up!",
+    "admin-password-help": "Back up this password and keep it safe! You cannot recover this password!",
+    "admin-password-backup": "I am using a strong password and have backed it up. (You cannot recover this password!)",
     "confirm-password": "Confirm password",
     "error-password-mismatch": "Passwords don't match",
     "join-federation": "Join Federation link",


### PR DESCRIPTION
made a couple minor changes:

- Forces you to start by generating a password, lets you edit it but improves likelihood they use the secure password
- Only generates once to clarify, found it confusing you could keep clicking it
- Moved acknowledgement checkmark for admin password to right above Next, was confusing having it super high up and can't see it when you scroll to bottom and the next is disabled