### PR TITLE
feat: confirmPassword

### DIFF
--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -61,6 +61,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
   const isSolo = role === GuardianRole.Solo;
   const [myName, setMyName] = useState(stateMyName);
   const [password, setPassword] = useState(statePassword);
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [passwordCheck, setPasswordCheck] = useState(Boolean);
   const [hostServerUrl, setHostServerUrl] = useState('');
   const [defaultParams, setDefaultParams] = useState<ConfigGenParams>();
@@ -126,6 +127,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
     ? Boolean(
         myName &&
           password &&
+          confirmPassword &&
           passwordCheck &&
           federationName &&
           isValidNumber(numPeers, 4) &&
@@ -137,6 +139,7 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
     ? Boolean(
         myName &&
           password &&
+          confirmPassword &&
           passwordCheck &&
           federationName &&
           isValidNumber(blockConfirmations, 1, 200) &&
@@ -271,6 +274,22 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
             <Button onClick={generatePassword} w='100%'>
               {t('set-config.admin-password-generate')}
             </Button>
+          )}
+          {password && (
+            <FormControl>
+              <FormLabel>{t('set-config.confirm-password')}</FormLabel>
+              <Input
+                type='password'
+                value={confirmPassword}
+                onChange={(ev) => setConfirmPassword(ev.currentTarget.value)}
+                placeholder='Confirm Password'
+              />
+              {password !== confirmPassword && (
+                <FormHelperText color='red'>
+                  {t('set-config.passwords-must-match')}
+                </FormHelperText>
+              )}
+            </FormControl>
           )}
           <FormHelperText style={{ marginTop: '16px', marginBottom: '16px' }}>
             <Text color={theme.colors.yellow[500]}>

--- a/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -275,6 +275,13 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
               {t('set-config.admin-password-generate')}
             </Button>
           )}
+          <FormHelperText style={{ marginTop: '16px', marginBottom: '16px' }}>
+            <Text color={theme.colors.yellow[500]}>
+              {password
+                ? t('set-config.admin-password-help')
+                : t('set-config.admin-password-set')}
+            </Text>
+          </FormHelperText>
           {password && (
             <FormControl>
               <FormLabel>{t('set-config.confirm-password')}</FormLabel>
@@ -286,18 +293,11 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
               />
               {password !== confirmPassword && (
                 <FormHelperText color='red'>
-                  {t('set-config.passwords-must-match')}
+                  {t('set-config.error-password-mismatch')}
                 </FormHelperText>
               )}
             </FormControl>
           )}
-          <FormHelperText style={{ marginTop: '16px', marginBottom: '16px' }}>
-            <Text color={theme.colors.yellow[500]}>
-              {password
-                ? t('set-config.admin-password-help')
-                : t('set-config.admin-password-set')}
-            </Text>
-          </FormHelperText>
         </FormControl>
         {!isHost && !isSolo && (
           <FormControl>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "eslint": "^8.4.1",
-    "husky": "^8.0.3",
+    "husky": "^9.0.11",
     "prettier": "^2.5.1",
     "pretty-quick": "^3.1.3",
     "turbo": "^1.12.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6475,10 +6475,10 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-husky@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+husky@^9.0.11:
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.11.tgz#fc91df4c756050de41b3e478b2158b87c1e79af9"
+  integrity sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==
 
 i18next-browser-languagedetector@^7.0.1:
   version "7.1.0"


### PR DESCRIPTION
reopen of https://github.com/fedimint/ui/pull/423

adds a confirm password modal before continuing during setup

![image](https://github.com/fedimint/ui/assets/74332828/cb5e5d83-2d00-4775-92e8-14dc9ed61d1d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a modal for password confirmation when setting configurations.
  
- **Enhancements**
  - Improved the configuration setup process by requiring password confirmation.

- **Dependencies**
  - Updated `husky` dependency from version `^8.0.3` to `^9.0.11`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->