### PR TITLE
feat: invite code in guardian auth

### DIFF
--- a/apps/guardian-ui/src/admin/FederationAdmin.tsx
+++ b/apps/guardian-ui/src/admin/FederationAdmin.tsx
@@ -93,7 +93,7 @@ export const FederationAdmin: React.FC = () => {
         {ourPeer ? (
           <FederationConfigCard config={config} ourPeer={ourPeer} />
         ) : null}
-        <DangerZone config={config} ourPeer={ourPeer} />
+        <DangerZone inviteCode={inviteCode} ourPeer={ourPeer} />
       </Flex>
     </Flex>
   );

--- a/apps/guardian-ui/src/assets/svgs/chevron-down.svg
+++ b/apps/guardian-ui/src/assets/svgs/chevron-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg>

--- a/apps/guardian-ui/src/assets/svgs/chevron-up.svg
+++ b/apps/guardian-ui/src/assets/svgs/chevron-up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-up"><polyline points="18 15 12 9 6 15"></polyline></svg>

--- a/apps/guardian-ui/src/components/dashboard/danger/DangerZone.tsx
+++ b/apps/guardian-ui/src/components/dashboard/danger/DangerZone.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
-import { Box, Text, Flex, theme } from '@chakra-ui/react';
+import React, { useState } from 'react';
+import { Box, Text, Flex, theme, Collapse, IconButton } from '@chakra-ui/react';
 import { GuardianAuthenticationCode } from './GuardianAuthenticationCode';
 import { DownloadBackup } from './DownloadBackup';
 import { useTranslation } from '@fedimint/utils';
+import { ReactComponent as ChevronDownIcon } from '../../../assets/svgs/chevron-down.svg';
+import { ReactComponent as ChevronUpIcon } from '../../../assets/svgs/chevron-up.svg';
 
 interface DangerZoneProps {
   ourPeer: { id: number; name: string } | undefined;
@@ -14,27 +16,53 @@ export const DangerZone: React.FC<DangerZoneProps> = ({
   inviteCode,
 }) => {
   const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleCollapse = () => setIsOpen(!isOpen);
 
   return (
-    <Box mt='12px' bg='red.50' p={2} borderRadius='md' maxW='480px'>
-      <Text
-        mb='6px'
-        fontSize='14px'
-        fontWeight='500'
-        color={theme.colors.gray[700]}
-      >
-        {t('federation-dashboard.danger-zone.danger-zone-label')}
-      </Text>
-      <Flex direction={['column', 'row']} alignItems='center' gap='6px'>
-        {ourPeer !== undefined && (
-          <GuardianAuthenticationCode
-            ourPeer={ourPeer}
-            inviteCode={inviteCode}
-          />
-        )}
-        <DownloadBackup />
+    <Box
+      mt='12px'
+      bg='red.50'
+      p={4}
+      borderRadius='md'
+      maxW='480px'
+      border='1px'
+      borderColor='red.200'
+    >
+      <Flex justifyContent='space-between' alignItems='center'>
+        <Text
+          mb='6px'
+          fontSize='16px'
+          fontWeight='600'
+          color={theme.colors.gray[800]}
+        >
+          {t('federation-dashboard.danger-zone.danger-zone-label')}
+        </Text>
+        <IconButton
+          onClick={toggleCollapse}
+          size='sm'
+          variant='ghost'
+          color='red.500'
+          icon={isOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}
+          aria-label='Toggle Danger Zone'
+          _hover={{ bg: 'red.100' }}
+          _active={{ bg: 'red.200' }}
+          mb='6px'
+        />
       </Flex>
-      <Text mt='6px' fontSize='14px' color={theme.colors.gray[500]}>
+      <Collapse in={isOpen} animateOpacity>
+        <Flex direction={['column', 'row']} alignItems='center' gap='6px'>
+          {ourPeer !== undefined && (
+            <GuardianAuthenticationCode
+              ourPeer={ourPeer}
+              inviteCode={inviteCode}
+            />
+          )}
+          <DownloadBackup />
+        </Flex>
+      </Collapse>
+      <Text mt='6px' fontSize='14px' color={theme.colors.gray[600]}>
         {t('federation-dashboard.danger-zone.danger-zone-description')}
       </Text>
     </Box>

--- a/apps/guardian-ui/src/components/dashboard/danger/DangerZone.tsx
+++ b/apps/guardian-ui/src/components/dashboard/danger/DangerZone.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { Box, Text, Flex, theme } from '@chakra-ui/react';
-import { ClientConfig } from '@fedimint/types';
 import { GuardianAuthenticationCode } from './GuardianAuthenticationCode';
 import { DownloadBackup } from './DownloadBackup';
 import { useTranslation } from '@fedimint/utils';
 
 interface DangerZoneProps {
-  config: ClientConfig | undefined;
   ourPeer: { id: number; name: string } | undefined;
+  inviteCode: string;
 }
 
-export const DangerZone: React.FC<DangerZoneProps> = ({ config, ourPeer }) => {
+export const DangerZone: React.FC<DangerZoneProps> = ({
+  ourPeer,
+  inviteCode,
+}) => {
   const { t } = useTranslation();
 
   return (
@@ -24,10 +26,10 @@ export const DangerZone: React.FC<DangerZoneProps> = ({ config, ourPeer }) => {
         {t('federation-dashboard.danger-zone.danger-zone-label')}
       </Text>
       <Flex direction={['column', 'row']} alignItems='center' gap='6px'>
-        {config && ourPeer !== undefined && (
+        {ourPeer !== undefined && (
           <GuardianAuthenticationCode
             ourPeer={ourPeer}
-            federationId={config.meta.federation_id ?? ''}
+            inviteCode={inviteCode}
           />
         )}
         <DownloadBackup />

--- a/apps/guardian-ui/src/components/dashboard/danger/GuardianAuthenticationCode.tsx
+++ b/apps/guardian-ui/src/components/dashboard/danger/GuardianAuthenticationCode.tsx
@@ -16,6 +16,13 @@ import QRCode from 'qrcode.react';
 
 const QR_CODE_SIZE = 256;
 
+type GuardianAuth = {
+  inviteCode: string;
+  peerId: number;
+  name: string;
+  password?: string;
+};
+
 interface GuardianAuthenticationCodeProps {
   inviteCode: string;
   ourPeer: { id: number; name: string };
@@ -31,18 +38,18 @@ export const GuardianAuthenticationCode: React.FC<
   const [isAcknowledged, setIsAcknowledged] = useState(false);
 
   const calculateGuardianAuthenticationCode = () => {
-    const params = new URLSearchParams({
+    const params: GuardianAuth = {
       inviteCode: inviteCode,
-      peerId: ourPeer?.id.toString(),
+      peerId: ourPeer?.id,
       name: ourPeer?.name,
-    });
+    };
 
     const password = sessionStorage.getItem('guardian-ui-key');
     if (password) {
-      params.append('password', password);
+      params.password = password;
     }
-    console.log(`fedimint:guardian?${params.toString()}`);
-    return `fedimint:guardian?${params.toString()}`;
+    console.log(`fedimint:guardian:${JSON.stringify(params)}`);
+    return `fedimint:guardian:${JSON.stringify(params)}`;
   };
 
   const handleOpen = () => {

--- a/apps/guardian-ui/src/components/dashboard/danger/GuardianAuthenticationCode.tsx
+++ b/apps/guardian-ui/src/components/dashboard/danger/GuardianAuthenticationCode.tsx
@@ -17,13 +17,13 @@ import QRCode from 'qrcode.react';
 const QR_CODE_SIZE = 256;
 
 interface GuardianAuthenticationCodeProps {
-  federationId: string;
+  inviteCode: string;
   ourPeer: { id: number; name: string };
 }
 
 export const GuardianAuthenticationCode: React.FC<
   GuardianAuthenticationCodeProps
-> = ({ federationId, ourPeer }) => {
+> = ({ inviteCode, ourPeer }) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -32,17 +32,17 @@ export const GuardianAuthenticationCode: React.FC<
 
   const calculateGuardianAuthenticationCode = () => {
     const params = new URLSearchParams({
-      federationId: federationId,
+      inviteCode: inviteCode,
       peerId: ourPeer?.id.toString(),
-      guardianName: ourPeer?.name,
+      name: ourPeer?.name,
     });
 
     const password = sessionStorage.getItem('guardian-ui-key');
     if (password) {
       params.append('password', password);
     }
-
-    return `guardian:authenticate?${params.toString()}`;
+    console.log(`fedimint:guardian?${params.toString()}`);
+    return `fedimint:guardian?${params.toString()}`;
   };
 
   const handleOpen = () => {

--- a/apps/guardian-ui/src/components/dashboard/danger/GuardianAuthenticationCode.tsx
+++ b/apps/guardian-ui/src/components/dashboard/danger/GuardianAuthenticationCode.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from '@fedimint/utils';
 import QRCode from 'qrcode.react';
 
 const QR_CODE_SIZE = 256;
+const FEDIMINT_GUARDIAN_PREFIX = 'fedimint:guardian:';
 
 type GuardianAuth = {
   inviteCode: string;
@@ -48,8 +49,7 @@ export const GuardianAuthenticationCode: React.FC<
     if (password) {
       params.password = password;
     }
-    console.log(`fedimint:guardian:${JSON.stringify(params)}`);
-    return `fedimint:guardian:${JSON.stringify(params)}`;
+    return `${FEDIMINT_GUARDIAN_PREFIX}${JSON.stringify(params)}`;
   };
 
   const handleOpen = () => {
@@ -89,7 +89,7 @@ export const GuardianAuthenticationCode: React.FC<
               >
                 <Text mb={4}>
                   {t(
-                    'federation-dashboard.danger-zone.guardian-warning-message'
+                    'federation-dashboard.danger-zone.guardian-warning-message',
                   )}
                 </Text>
                 <Flex
@@ -113,7 +113,7 @@ export const GuardianAuthenticationCode: React.FC<
                     }}
                   >
                     {t(
-                      'federation-dashboard.danger-zone.acknowledge-and-download'
+                      'federation-dashboard.danger-zone.acknowledge-and-download',
                     )}
                   </Button>
                 </Flex>
@@ -135,7 +135,7 @@ export const GuardianAuthenticationCode: React.FC<
                 />
                 <Text fontWeight={'bold'} color={'red'} mt={4}>
                   {t(
-                    'federation-dashboard.danger-zone.guardian-connect-warning'
+                    'federation-dashboard.danger-zone.guardian-connect-warning',
                   )}
                 </Text>
               </Flex>


### PR DESCRIPTION
Was working on this today and not putting the inviteCode in the auth means you have to separately connect as a client then auth as a guardian.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the `DangerZone` component to accept an `inviteCode` for improved user authentication and configuration handling.
  
- **Improvements**
  - Enhanced the `GuardianAuthenticationCode` component to use a more detailed `GuardianAuth` type, enhancing security and functionality.
  
- **Refactor**
  - Modified internal logic for `DangerZone` and `GuardianAuthenticationCode` components to align with new prop and type structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->