### PR TITLE
Add Peer ID to Federation Admin dashboard

### DIFF
--- a/apps/guardian-ui/src/admin/FederationAdmin.tsx
+++ b/apps/guardian-ui/src/admin/FederationAdmin.tsx
@@ -165,6 +165,7 @@ export const FederationAdmin: React.FC = () => {
           status={status}
           config={config}
           signedApiAnnouncements={signedApiAnnouncements}
+          ourPeer={ourPeer}
         />
         <GatewaysCard config={config} />
         {ourPeer && (

--- a/apps/guardian-ui/src/admin/FederationAdmin.tsx
+++ b/apps/guardian-ui/src/admin/FederationAdmin.tsx
@@ -165,7 +165,6 @@ export const FederationAdmin: React.FC = () => {
           status={status}
           config={config}
           signedApiAnnouncements={signedApiAnnouncements}
-          ourPeer={ourPeer}
         />
         <GatewaysCard config={config} />
         {ourPeer && (

--- a/apps/guardian-ui/src/components/dashboard/guardians/GuardiansCard.tsx
+++ b/apps/guardian-ui/src/components/dashboard/guardians/GuardiansCard.tsx
@@ -9,18 +9,26 @@ import {
 import { StatusIndicator, Table, TableColumn, TableRow } from '@fedimint/ui';
 import { useTranslation } from '@fedimint/utils';
 
-type TableKey = 'name' | 'status' | 'health' | 'lastContribution' | 'apiUrl';
+type TableKey =
+  | 'peerId'
+  | 'name'
+  | 'status'
+  | 'health'
+  | 'lastContribution'
+  | 'apiUrl';
 
 interface Props {
   status: StatusResponse | undefined;
   config: ClientConfig | undefined;
   signedApiAnnouncements: Record<string, SignedApiAnnouncement>;
+  ourPeer: { id: number; name: string } | undefined;
 }
 
 export const GuardiansCard: React.FC<Props> = ({
   status,
   config,
   signedApiAnnouncements,
+  ourPeer,
 }) => {
   const { t } = useTranslation();
 
@@ -46,6 +54,10 @@ export const GuardiansCard: React.FC<Props> = ({
         key: 'apiUrl',
         heading: t('federation-dashboard.guardians.api-url-label'),
       },
+      {
+        key: 'peerId',
+        heading: t('federation-dashboard.guardians.peer-id-label'),
+      },
     ],
     [t]
   );
@@ -62,6 +74,7 @@ export const GuardiansCard: React.FC<Props> = ({
       if (endpoint) {
         peerDataArray.push({
           key: id,
+          peerId: ourPeer?.id === numericId ? `${numericId} (You)` : numericId,
           name: endpoint.name,
           status: (
             <StatusIndicator
@@ -92,7 +105,7 @@ export const GuardiansCard: React.FC<Props> = ({
       }
     }
     return peerDataArray;
-  }, [status, config, signedApiAnnouncements, t]);
+  }, [status, config, signedApiAnnouncements, t, ourPeer]);
 
   if (config && !rows.length) {
     return null;

--- a/apps/guardian-ui/src/components/dashboard/guardians/GuardiansCard.tsx
+++ b/apps/guardian-ui/src/components/dashboard/guardians/GuardiansCard.tsx
@@ -9,13 +9,7 @@ import {
 import { StatusIndicator, Table, TableColumn, TableRow } from '@fedimint/ui';
 import { useTranslation } from '@fedimint/utils';
 
-type TableKey =
-  | 'peerId'
-  | 'name'
-  | 'status'
-  | 'health'
-  | 'lastContribution'
-  | 'apiUrl';
+type TableKey = 'idName' | 'status' | 'health' | 'lastContribution' | 'apiUrl';
 
 interface Props {
   status: StatusResponse | undefined;
@@ -35,8 +29,8 @@ export const GuardiansCard: React.FC<Props> = ({
   const columns: TableColumn<TableKey>[] = useMemo(
     () => [
       {
-        key: 'name',
-        heading: t('federation-dashboard.guardians.name-label'),
+        key: 'idName',
+        heading: t('federation-dashboard.guardians.id-name-label'),
       },
       {
         key: 'status',
@@ -54,10 +48,6 @@ export const GuardiansCard: React.FC<Props> = ({
         key: 'apiUrl',
         heading: t('federation-dashboard.guardians.api-url-label'),
       },
-      {
-        key: 'peerId',
-        heading: t('federation-dashboard.guardians.peer-id-label'),
-      },
     ],
     [t]
   );
@@ -74,8 +64,10 @@ export const GuardiansCard: React.FC<Props> = ({
       if (endpoint) {
         peerDataArray.push({
           key: id,
-          peerId: ourPeer?.id === numericId ? `${numericId} (You)` : numericId,
-          name: endpoint.name,
+          idName:
+            ourPeer?.id === numericId
+              ? `${numericId}: ${ourPeer.name} (You)`
+              : numericId,
           status: (
             <StatusIndicator
               status={

--- a/apps/guardian-ui/src/components/dashboard/guardians/GuardiansCard.tsx
+++ b/apps/guardian-ui/src/components/dashboard/guardians/GuardiansCard.tsx
@@ -15,14 +15,12 @@ interface Props {
   status: StatusResponse | undefined;
   config: ClientConfig | undefined;
   signedApiAnnouncements: Record<string, SignedApiAnnouncement>;
-  ourPeer: { id: number; name: string } | undefined;
 }
 
 export const GuardiansCard: React.FC<Props> = ({
   status,
   config,
   signedApiAnnouncements,
-  ourPeer,
 }) => {
   const { t } = useTranslation();
 
@@ -64,10 +62,7 @@ export const GuardiansCard: React.FC<Props> = ({
       if (endpoint) {
         peerDataArray.push({
           key: id,
-          idName:
-            ourPeer?.id === numericId
-              ? `${numericId}: ${ourPeer.name} (You)`
-              : numericId,
+          idName: `${numericId}: ${endpoint.name}`,
           status: (
             <StatusIndicator
               status={
@@ -97,7 +92,7 @@ export const GuardiansCard: React.FC<Props> = ({
       }
     }
     return peerDataArray;
-  }, [status, config, signedApiAnnouncements, t, ourPeer]);
+  }, [status, config, signedApiAnnouncements, t]);
 
   if (config && !rows.length) {
     return null;

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -55,14 +55,13 @@
     },
     "guardians": {
       "label": "Other Guardians",
-      "name-label": "Name",
+      "id-name-label": "ID: Name",
       "status-label": "Connection Status",
       "health-label": "Health",
       "health-issue": "Issue",
       "health-good": "Good",
       "last-contribution-label": "Last contribution block",
-      "api-url-label": "API URL",
-      "peer-id-label": "Peer ID"
+      "api-url-label": "API URL"
     },
     "gateways": {
       "label": "Lightning Gateways",

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -39,6 +39,7 @@
       "block-count-label": "Consensus Block Height",
       "api-version-label": "API version",
       "consensus-version-label": "Consensus version",
+      "peer-id-label": "Peer ID",
       "session-info": {
         "session-height": "Session Height",
         "latest-session": "Latest Session"
@@ -60,7 +61,8 @@
       "health-issue": "Issue",
       "health-good": "Good",
       "last-contribution-label": "Last contribution block",
-      "api-url-label": "API URL"
+      "api-url-label": "API URL",
+      "peer-id-label": "Peer ID"
     },
     "gateways": {
       "label": "Lightning Gateways",


### PR DESCRIPTION
Fixes #181 
Adds peerID column in the Other Guardians section of the dashboard!
<img width="1162" alt="Screenshot 2024-08-05 at 5 23 34 PM" src="https://github.com/user-attachments/assets/e28404e9-f02a-431a-843d-7f1a2771a28a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new prop `ourPeer` in the FederationAdmin component for enhanced functionality.
	- Updated GuardiansCard to include user-specific data with the addition of `idName` and `ourPeer` properties.
	- Added localization support for "peer-id-label" to improve user interface clarity.

These changes enhance the overall user experience by providing more contextual information and improving component interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->