### PR TITLE
fix: disable back while at connectGuardians

### DIFF
--- a/apps/guardian-ui/src/setup/FederationSetup.tsx
+++ b/apps/guardian-ui/src/setup/FederationSetup.tsx
@@ -142,7 +142,7 @@ export const FederationSetup: React.FC = () => {
         ? t('setup.progress.connect-guardians.subtitle-leader')
         : t('setup.progress.connect-guardians.subtitle-follower');
       content = <ConnectGuardians next={handleNext} />;
-      canGoBack = true;
+      canGoBack = false;
       canRestart = true;
       break;
     case SetupProgress.RunDKG:


### PR DESCRIPTION
You have to restart the whole ceremony after connecting a Guardian, so disables back button for host and followers once they get to the point where they've moved their state along for ConnectGuardians. The host can still restart the full ceremony.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the setup process to restrict navigation by disabling the ability to go back during the FederationSetup phase, enhancing control over the user flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->