### PR TITLE
chore: using util for unclear conversion

### DIFF
--- a/apps/gateway-ui/src/components/DepositCard.tsx
+++ b/apps/gateway-ui/src/components/DepositCard.tsx
@@ -10,7 +10,8 @@ import {
 } from '@chakra-ui/react';
 import { ApiContext } from '../ApiProvider';
 import { QRCodeSVG } from 'qrcode.react';
-import { Network } from '@fedimint/types';
+import { MSats, Network } from '@fedimint/types';
+import { formatMsatsToBtc } from '@fedimint/utils';
 import { useTranslation } from '@fedimint/utils';
 import { GatewayCard } from './GatewayCard';
 import { ReactComponent as CopyIcon } from '../assets/svgs/copy.svg';
@@ -44,7 +45,9 @@ export const DepositCard = React.memo(function DepositCard({
       .fetchAddress(federationId)
       .then((newAddress) => {
         const bip21Uri = `bitcoin:${newAddress}${
-          amount > 0 ? `?amount=${amount / 100000000}` : ''
+          amount > 0
+            ? `?amount=${formatMsatsToBtc((amount * 1000) as MSats)}`
+            : ''
         }`;
         setAddress(bip21Uri);
         setError('');


### PR DESCRIPTION
Fixes #182 
by using the utility function to avoid unclear conversion of sats!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `DepositCard` component to support Bitcoin amount formatting in milli-satoshis (MSats), improving accuracy and clarity in amount representation.

- **Improvements**
	- Updated logic for converting amounts from milli-satoshis to Bitcoin, ensuring more precise display of cryptocurrency values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->