### PR TITLE
feat: Dynamically set the config_api_url

### DIFF
--- a/apps/guardian-ui/src/App.tsx
+++ b/apps/guardian-ui/src/App.tsx
@@ -45,7 +45,7 @@ export const App = React.memo(function App() {
     if (state.status === Status.NotConfigured) {
       return (
         <Wrapper>
-          <NotConfigured api={api} state={state} dispatch={dispatch} />
+          <NotConfigured api={api} dispatch={dispatch} />
         </Wrapper>
       );
     }
@@ -92,7 +92,15 @@ export const App = React.memo(function App() {
         <Spinner size='xl' />
       </Center>
     );
-  }, [state, api, dispatch, t]);
+  }, [
+    state.status,
+    state.appError,
+    state.needsAuth,
+    state.initServerStatus,
+    api,
+    dispatch,
+    t,
+  ]);
 
   return (
     <React.StrictMode>

--- a/apps/guardian-ui/src/App.tsx
+++ b/apps/guardian-ui/src/App.tsx
@@ -17,6 +17,7 @@ import { useAppContext } from './hooks';
 import { useTranslation } from '@fedimint/utils';
 import { APP_ACTION_TYPE, Status } from './types';
 import { formatApiErrorMessage } from './utils/api';
+import { NotConfigured } from './components/NotConfigured';
 
 export const App = React.memo(function App() {
   const { t } = useTranslation();
@@ -38,6 +39,14 @@ export const App = React.memo(function App() {
           </Heading>
           <Text fontSize='md'>{state.appError}</Text>
         </Flex>
+      );
+    }
+
+    if (state.status === Status.NotConfigured) {
+      return (
+        <Wrapper>
+          <NotConfigured api={api} state={state} dispatch={dispatch} />
+        </Wrapper>
       );
     }
 
@@ -83,15 +92,7 @@ export const App = React.memo(function App() {
         <Spinner size='xl' />
       </Center>
     );
-  }, [
-    state.status,
-    state.initServerStatus,
-    state.appError,
-    state.needsAuth,
-    api,
-    dispatch,
-    t,
-  ]);
+  }, [state, api, dispatch, t]);
 
   return (
     <React.StrictMode>

--- a/apps/guardian-ui/src/AppContext.tsx
+++ b/apps/guardian-ui/src/AppContext.tsx
@@ -58,7 +58,15 @@ export const AppContextProvider: React.FC<AppContextProviderProps> = ({
   useEffect(() => {
     const load = async () => {
       try {
-        await api.connect();
+        const guardianConfig = await api.getGuardianConfig();
+        if (!guardianConfig?.fm_config_api) {
+          dispatch({
+            type: APP_ACTION_TYPE.SET_STATUS,
+            payload: Status.NotConfigured,
+          });
+          return;
+        }
+        await api.connect(guardianConfig.fm_config_api);
         const server = (await api.status()).server;
 
         // If they're at a point where a password has been configured, make

--- a/apps/guardian-ui/src/components/NotConfigured.tsx
+++ b/apps/guardian-ui/src/components/NotConfigured.tsx
@@ -11,11 +11,10 @@ import {
 } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
 import { GuardianApi } from '../GuardianApi';
-import { AppState, APP_ACTION_TYPE, Status, AppAction } from '../types';
+import { APP_ACTION_TYPE, Status, AppAction } from '../types';
 
 interface NotConfiguredProps {
   api: GuardianApi;
-  state: AppState;
   dispatch: React.Dispatch<AppAction>;
 }
 

--- a/apps/guardian-ui/src/components/NotConfigured.tsx
+++ b/apps/guardian-ui/src/components/NotConfigured.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useState } from 'react';
+import {
+  Button,
+  Flex,
+  Heading,
+  Input,
+  Text,
+  FormControl,
+  FormLabel,
+  FormErrorMessage,
+} from '@chakra-ui/react';
+import { useTranslation } from '@fedimint/utils';
+import { GuardianApi } from '../GuardianApi';
+import { AppState, APP_ACTION_TYPE, Status, AppAction } from '../types';
+
+interface NotConfiguredProps {
+  api: GuardianApi;
+  state: AppState;
+  dispatch: React.Dispatch<AppAction>;
+}
+
+export const NotConfigured: React.FC<NotConfiguredProps> = ({
+  api,
+  dispatch,
+}) => {
+  const { t } = useTranslation();
+  const [configUrl, setConfigUrl] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+
+      try {
+        await api.setGuardianConfig({ fm_config_api: configUrl });
+        dispatch({ type: APP_ACTION_TYPE.SET_STATUS, payload: Status.Loading });
+      } catch (err) {
+        setError(t('errors.invalidConfig'));
+      }
+    },
+    [api, configUrl, dispatch, t]
+  );
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Flex direction='column' pt={8} gap={4} align='start' justify='start'>
+        <Flex direction='column' align='start' gap={4}>
+          <Heading size='md' fontWeight='medium'>
+            {t('notConfigured.title')}
+          </Heading>
+          <Text size='md' fontWeight='medium'>
+            {t('notConfigured.description')}
+          </Text>
+        </Flex>
+        <FormControl isInvalid={!!error}>
+          <FormLabel>{t('notConfigured.urlLabel')}</FormLabel>
+          <Input
+            placeholder={t('notConfigured.urlPlaceholder')}
+            value={configUrl}
+            onChange={(e) => setConfigUrl(e.target.value)}
+          />
+          {error && <FormErrorMessage>{error}</FormErrorMessage>}
+        </FormControl>
+        <Button type='submit'>{t('common.submit')}</Button>
+      </Flex>
+    </form>
+  );
+};

--- a/apps/guardian-ui/src/components/NotConfigured.tsx
+++ b/apps/guardian-ui/src/components/NotConfigured.tsx
@@ -55,7 +55,7 @@ export const NotConfigured: React.FC<NotConfiguredProps> = ({
         <FormControl isInvalid={!!error}>
           <FormLabel>{t('notConfigured.urlLabel')}</FormLabel>
           <Input
-            placeholder={t('notConfigured.urlPlaceholder')}
+            placeholder={'wss://fedimintd.my-awesome-domain.com:6000'}
             value={configUrl}
             onChange={(e) => setConfigUrl(e.target.value)}
           />

--- a/apps/guardian-ui/src/languages/ca.json
+++ b/apps/guardian-ui/src/languages/ca.json
@@ -17,7 +17,14 @@
     "you": "Tu",
     "close": "Tanca",
     "save": "Desaureta",
-    "continue": "Continuar"
+    "continue": "Continuar",
+    "submit": "Enviar"
+  },
+  "notConfigured": {
+    "title": "No Configurat",
+    "description": "Introduïu l'URL de l'API de configuració de Fedimint per continuar.",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000",
+    "submit": "Enviar"
   },
   "connect-guardians": {
     "invite-guardians": "Convida els seguidors",

--- a/apps/guardian-ui/src/languages/ca.json
+++ b/apps/guardian-ui/src/languages/ca.json
@@ -22,9 +22,7 @@
   },
   "notConfigured": {
     "title": "No Configurat",
-    "description": "Introduïu l'URL de l'API de configuració de Fedimint per continuar.",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000",
-    "submit": "Enviar"
+    "description": "Introduïu l'URL de l'API de configuració de Fedimint per continuar."
   },
   "connect-guardians": {
     "invite-guardians": "Convida els seguidors",

--- a/apps/guardian-ui/src/languages/de.json
+++ b/apps/guardian-ui/src/languages/de.json
@@ -22,8 +22,7 @@
   },
   "notConfigured": {
     "title": "Nicht konfiguriert",
-    "description": "Bitte geben Sie die CONFIG_API_URL des Fedimint-Wächter-Servers ein, um fortzufahren.",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "Bitte geben Sie die CONFIG_API_URL des Fedimint-Wächter-Servers ein, um fortzufahren."
   },
   "connect-guardians": {
     "invite-guardians": "Follower einladen",

--- a/apps/guardian-ui/src/languages/de.json
+++ b/apps/guardian-ui/src/languages/de.json
@@ -17,7 +17,13 @@
     "you": "Du",
     "close": "Schließen",
     "save": "Speichern",
-    "continue": "Fortsetzen"
+    "continue": "Fortsetzen",
+    "submit": "Einreichen"
+  },
+  "notConfigured": {
+    "title": "Nicht konfiguriert",
+    "description": "Bitte geben Sie die CONFIG_API_URL des Fedimint-Wächter-Servers ein, um fortzufahren.",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "invite-guardians": "Follower einladen",

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -22,8 +22,7 @@
   },
   "notConfigured": {
     "title": "Not Configured",
-    "description": "Please enter the CONFIG_API_URL of the Fedimint guardian server to point at.",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "Please enter the CONFIG_API_URL of the Fedimint guardian server to point at."
   },
   "connect-guardians": {
     "invite-guardians": "Invite Followers",

--- a/apps/guardian-ui/src/languages/en.json
+++ b/apps/guardian-ui/src/languages/en.json
@@ -17,7 +17,13 @@
     "you": "You",
     "close": "Close",
     "save": "Save",
-    "continue": "Continue"
+    "continue": "Continue",
+    "submit": "Submit"
+  },
+  "notConfigured": {
+    "title": "Not Configured",
+    "description": "Please enter the CONFIG_API_URL of the Fedimint guardian server to point at.",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "invite-guardians": "Invite Followers",

--- a/apps/guardian-ui/src/languages/es.json
+++ b/apps/guardian-ui/src/languages/es.json
@@ -20,7 +20,13 @@
     "you": "Tú",
     "close": "Cerrar",
     "save": "Guardar",
-    "continue": "Continuar"
+    "continue": "Continuar",
+    "submit": "Enviar"
+  },
+  "notConfigured": {
+    "title": "No configurado",
+    "description": "Por favor, ingrese la URL del servidor de configuración de Fedimint para continuar.",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "invite-guardians": "Invitar seguidores",

--- a/apps/guardian-ui/src/languages/es.json
+++ b/apps/guardian-ui/src/languages/es.json
@@ -25,8 +25,7 @@
   },
   "notConfigured": {
     "title": "No configurado",
-    "description": "Por favor, ingrese la URL del servidor de configuración de Fedimint para continuar.",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "Por favor, ingrese la URL del servidor de configuración de Fedimint para continuar."
   },
   "connect-guardians": {
     "invite-guardians": "Invitar seguidores",

--- a/apps/guardian-ui/src/languages/fr.json
+++ b/apps/guardian-ui/src/languages/fr.json
@@ -17,7 +17,13 @@
     "you": "Vous",
     "close": "Fermer",
     "save": "Sauvegarder",
-    "continue": "Continuer"
+    "continue": "Continuer",
+    "submit": "Envoyer"
+  },
+  "notConfigured": {
+    "title": "Non configuré",
+    "description": "Veuillez entrer l'URL du serveur de configuration Fedimint pour continuer.",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "invite-guardians": "Inviter des abonnés",

--- a/apps/guardian-ui/src/languages/fr.json
+++ b/apps/guardian-ui/src/languages/fr.json
@@ -22,8 +22,7 @@
   },
   "notConfigured": {
     "title": "Non configuré",
-    "description": "Veuillez entrer l'URL du serveur de configuration Fedimint pour continuer.",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "Veuillez entrer l'URL du serveur de configuration Fedimint pour continuer."
   },
   "connect-guardians": {
     "invite-guardians": "Inviter des abonnés",

--- a/apps/guardian-ui/src/languages/hu.json
+++ b/apps/guardian-ui/src/languages/hu.json
@@ -21,8 +21,8 @@
     "submit": "Küldés"
   },
   "notConfigured": {
-    "title": "Non configurato",
-    "description": "Per favore, inserisci l'URL del server di configurazione Fedimint per continuare.",
+    "title": "Nincs konfigurálva",
+    "description": "Kérjük, adja meg a Fedimint konfigurációs szerver URL-jét a folytatáshoz.",
     "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {

--- a/apps/guardian-ui/src/languages/hu.json
+++ b/apps/guardian-ui/src/languages/hu.json
@@ -22,8 +22,7 @@
   },
   "notConfigured": {
     "title": "Nincs konfigurálva",
-    "description": "Kérjük, adja meg a Fedimint konfigurációs szerver URL-jét a folytatáshoz.",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "Kérjük, adja meg a Fedimint konfigurációs szerver URL-jét a folytatáshoz."
   },
   "connect-guardians": {
     "invite-guardians": "Kövesd a követőket",

--- a/apps/guardian-ui/src/languages/hu.json
+++ b/apps/guardian-ui/src/languages/hu.json
@@ -17,7 +17,13 @@
     "you": "Te",
     "close": "Bezárás",
     "save": "Mentés",
-    "continue": "Folytatás"
+    "continue": "Folytatás",
+    "submit": "Küldés"
+  },
+  "notConfigured": {
+    "title": "Non configurato",
+    "description": "Per favore, inserisci l'URL del server di configurazione Fedimint per continuare.",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "invite-guardians": "Kövesd a követőket",

--- a/apps/guardian-ui/src/languages/it.json
+++ b/apps/guardian-ui/src/languages/it.json
@@ -22,8 +22,7 @@
   },
   "notConfigured": {
     "title": "Non configurato",
-    "description": "Per favore, inserisci l'URL del server di configurazione Fedimint per continuare.",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "Per favore, inserisci l'URL del server di configurazione Fedimint per continuare."
   },
   "connect-guardians": {
     "invite-guardians": "Invitar seguidores",

--- a/apps/guardian-ui/src/languages/it.json
+++ b/apps/guardian-ui/src/languages/it.json
@@ -17,7 +17,13 @@
     "you": "Tu",
     "close": "Cerrar",
     "save": "Guardar",
-    "continue": "Continuar"
+    "continue": "Continuar",
+    "submit": "Enviar"
+  },
+  "notConfigured": {
+    "title": "Non configurato",
+    "description": "Per favore, inserisci l'URL del server di configurazione Fedimint per continuare.",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "invite-guardians": "Invitar seguidores",

--- a/apps/guardian-ui/src/languages/ja.json
+++ b/apps/guardian-ui/src/languages/ja.json
@@ -17,7 +17,13 @@
     "you": "あなた",
     "close": "閉じる",
     "save": "保存",
-    "continue": "続ける"
+    "continue": "続ける",
+    "submit": "送信"
+  },
+  "notConfigured": {
+    "title": "未構成",
+    "description": "Fedimintの構成サーバーのURLを入力してください。",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "invite-guardians": "フォロワーを招待する",

--- a/apps/guardian-ui/src/languages/ja.json
+++ b/apps/guardian-ui/src/languages/ja.json
@@ -22,8 +22,7 @@
   },
   "notConfigured": {
     "title": "未構成",
-    "description": "Fedimintの構成サーバーのURLを入力してください。",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "Fedimintの構成サーバーのURLを入力してください。"
   },
   "connect-guardians": {
     "invite-guardians": "フォロワーを招待する",

--- a/apps/guardian-ui/src/languages/ko.json
+++ b/apps/guardian-ui/src/languages/ko.json
@@ -22,8 +22,7 @@
   },
   "notConfigured": {
     "title": "미구성",
-    "description": "Fedimint 구성 서버의 URL을 입력하세요.",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "Fedimint 구성 서버의 URL을 입력하세요."
   },
   "connect-guardians": {
     "approve": "승인",

--- a/apps/guardian-ui/src/languages/ko.json
+++ b/apps/guardian-ui/src/languages/ko.json
@@ -17,7 +17,13 @@
     "you": "당신",
     "close": "닫기",
     "save": "저장",
-    "continue": "계속하다"
+    "continue": "계속하다",
+    "submit": "제출"
+  },
+  "notConfigured": {
+    "title": "미구성",
+    "description": "Fedimint 구성 서버의 URL을 입력하세요.",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "approve": "승인",

--- a/apps/guardian-ui/src/languages/pt.json
+++ b/apps/guardian-ui/src/languages/pt.json
@@ -17,8 +17,8 @@
     "you": "Você",
     "close": "Fechar",
     "save": "Salvar",
-    "continue": "Continue",
-    "submit": "Submit"
+    "continue": "Continuar",
+    "submit": "Enviar"
   },
   "notConfigured": {
     "title": "Não configurado",

--- a/apps/guardian-ui/src/languages/pt.json
+++ b/apps/guardian-ui/src/languages/pt.json
@@ -17,7 +17,13 @@
     "you": "Você",
     "close": "Fechar",
     "save": "Salvar",
-    "continue": "Continue"
+    "continue": "Continue",
+    "submit": "Submit"
+  },
+  "notConfigured": {
+    "title": "Não configurado",
+    "description": "Por favor, insira a URL do servidor de configuração Fedimint para continuar.",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "invite-guardians": "Convidar Seguidores",

--- a/apps/guardian-ui/src/languages/pt.json
+++ b/apps/guardian-ui/src/languages/pt.json
@@ -22,8 +22,7 @@
   },
   "notConfigured": {
     "title": "Não configurado",
-    "description": "Por favor, insira a URL do servidor de configuração Fedimint para continuar.",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "Por favor, insira a URL do servidor de configuração Fedimint para continuar."
   },
   "connect-guardians": {
     "invite-guardians": "Convidar Seguidores",

--- a/apps/guardian-ui/src/languages/ru.json
+++ b/apps/guardian-ui/src/languages/ru.json
@@ -17,7 +17,13 @@
     "you": "Ты",
     "close": "Закрыть",
     "save": "Сохранить",
-    "continue": "Продолжить"
+    "continue": "Продолжить",
+    "submit": "Отправить"
+  },
+  "notConfigured": {
+    "title": "Не настроен",
+    "description": "Пожалуйста, введите URL сервера конфигурации Fedimint для продолжения.",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "invite-guardians": "Пригласить подписчиков",

--- a/apps/guardian-ui/src/languages/ru.json
+++ b/apps/guardian-ui/src/languages/ru.json
@@ -22,8 +22,7 @@
   },
   "notConfigured": {
     "title": "Не настроен",
-    "description": "Пожалуйста, введите URL сервера конфигурации Fedimint для продолжения.",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "Пожалуйста, введите URL сервера конфигурации Fedimint для продолжения."
   },
   "connect-guardians": {
     "invite-guardians": "Пригласить подписчиков",

--- a/apps/guardian-ui/src/languages/zh.json
+++ b/apps/guardian-ui/src/languages/zh.json
@@ -17,7 +17,13 @@
     "you": "你",
     "close": "关闭",
     "save": "保存",
-    "continue": "继续"
+    "continue": "继续",
+    "submit": "提交"
+  },
+  "notConfigured": {
+    "title": "未配置",
+    "description": "请输入Fedimint配置服务器的URL以继续。",
+    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
   },
   "connect-guardians": {
     "invite-guardians": "邀请关注者",

--- a/apps/guardian-ui/src/languages/zh.json
+++ b/apps/guardian-ui/src/languages/zh.json
@@ -22,8 +22,7 @@
   },
   "notConfigured": {
     "title": "未配置",
-    "description": "请输入Fedimint配置服务器的URL以继续。",
-    "urlPlaceholder": "wss://fedimintd.my-awesome-domain.com:6000"
+    "description": "请输入Fedimint配置服务器的URL以继续。"
   },
   "connect-guardians": {
     "invite-guardians": "邀请关注者",

--- a/apps/guardian-ui/src/types.tsx
+++ b/apps/guardian-ui/src/types.tsx
@@ -1,6 +1,7 @@
 import { Peer, ServerStatus, ConfigGenParams } from '@fedimint/types';
 
 export enum Status {
+  NotConfigured,
   Loading,
   Setup,
   Admin,

--- a/mprocs-nix-guardian.yml
+++ b/mprocs-nix-guardian.yml
@@ -22,7 +22,7 @@ procs:
     shell: yarn dev:guardian-ui
     env:
       PORT: '3000'
-      REACT_APP_FM_CONFIG_API: ws://127.0.0.1:18138
+      # REACT_APP_FM_CONFIG_API: ws://127.0.0.1:18138
       BROWSER: none
   guardian-ui-2:
     shell: yarn dev:guardian-ui

--- a/mprocs-nix-guardian.yml
+++ b/mprocs-nix-guardian.yml
@@ -22,7 +22,7 @@ procs:
     shell: yarn dev:guardian-ui
     env:
       PORT: '3000'
-      # REACT_APP_FM_CONFIG_API: ws://127.0.0.1:18138
+      REACT_APP_FM_CONFIG_API: ws://127.0.0.1:18138
       BROWSER: none
   guardian-ui-2:
     shell: yarn dev:guardian-ui


### PR DESCRIPTION
If you don't set it in the config, lets you set it in the UI and point it at whatever guardian you want.

More of a dev tool and for easy deploy previews, not recommended for production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `NotConfigured` component to guide users when the application is not set up correctly.
	- Enhanced the UI with conditional rendering based on application status.
	- Added new language translations for submit actions and configuration prompts in Hungarian and Portuguese.

- **Bug Fixes**
	- Improved error handling for invalid configuration submissions.

- **Documentation**
	- Updated language files to enhance user guidance in Hungarian and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->