### PR TITLE
feat: add ldk gateway in mprocs

### DIFF
--- a/mprocs-nix-gateway.yml
+++ b/mprocs-nix-gateway.yml
@@ -10,6 +10,8 @@ procs:
     shell: tail -n +0 -F $FM_LOGS_DIR/fedimintd-default-2.log
   fedimint3:
     shell: tail -n +0 -F $FM_LOGS_DIR/fedimintd-default-3.log
+  ldk-gw:
+    shell: tail -n +0 -F $FM_LOGS_DIR/gatewayd-ldk.log
   cln-gw:
     shell: tail -n +0 -F $FM_LOGS_DIR/gatewayd-cln.log
   lnd-gw:

--- a/mprocs-nix-guardian.yml
+++ b/mprocs-nix-guardian.yml
@@ -42,10 +42,3 @@ procs:
       PORT: '3003'
       REACT_APP_FM_CONFIG_API: ws://127.0.0.1:18144
       BROWSER: none
-  gateway-ui:
-    shell: bash --init-file scripts/mprocs-nix-gateway.sh
-    stop: SIGKILL
-    env:
-      PORT: '3004'
-      REACT_APP_FM_GATEWAY_PASSWORD: 'thereisnosecondbest'
-      BROWSER: none

--- a/scripts/mprocs-user-shell.sh
+++ b/scripts/mprocs-user-shell.sh
@@ -5,8 +5,7 @@ eval "$(devimint env)"
 echo Waiting for devimint to start up fedimint
 
 STATUS="$(devimint wait)"
-if [ "$STATUS" = "ERROR" ]
-then
+if [ "$STATUS" = "ERROR" ]; then
     echo "fedimint didn't start correctly"
     echo "See other panes for errors"
     exit 1
@@ -18,6 +17,7 @@ alias bitcoin-cli="\$FM_BTC_CLIENT"
 alias fedimint-cli="\$FM_MINT_CLIENT"
 alias gateway-cln="\$FM_GWCLI_CLN"
 alias gateway-lnd="\$FM_GWCLI_LND"
+alias gateway-ldk="\$FM_GWCLI_LDK"
 
 eval "$(fedimint-cli completion bash)" || true
 eval "$(gateway-cli completion bash)" || true
@@ -32,6 +32,7 @@ echo "  lncli          - cli client for LND"
 echo "  bitcoin-cli    - cli client for bitcoind"
 echo "  gateway-cln    - cli client for the CLN gateway"
 echo "  gateway-lnd    - cli client for the LND gateway"
+echo "  gateway-ldk    - cli client for the LDK gateway"
 echo
 echo "Use '--help' on each command for more information"
 echo ""


### PR DESCRIPTION
Adds ldk in mprocs, devimint's already starting it on the recent fedimint versions we just didn't have a process for trailing the logfile

also removes unused gateway-ui in `just guardian`, had that there for testing and shouldn't have committed it into master

![image](https://github.com/user-attachments/assets/652188f1-f612-4ab9-bccd-8e3a600d65d8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced real-time logging capabilities for the `gatewayd-ldk` process, allowing users to monitor logs directly.
	- Added a new command-line alias for `gateway-ldk`, enhancing usability for users interacting with the LDK gateway.

- **Bug Fixes**
	- Removed outdated `gateway-ui` process configuration, streamlining the deployment process.

- **Documentation**
	- Updated help output in the user shell script to include the new `gateway-ldk` alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->