### PR TITLE
Reduce gateway login width

### DIFF
--- a/packages/ui/src/Login.tsx
+++ b/packages/ui/src/Login.tsx
@@ -62,7 +62,7 @@ export const Login: React.FC<LoginProps> = ({
             {t('login.subtitle')}
           </Text>
         </Flex>
-        <FormControl isInvalid={!!error}>
+        <FormControl isInvalid={!!error} maxW='480px'>
           <FormLabel>{t('login.password')}</FormLabel>
           <InputGroup size='md'>
             <Input


### PR DESCRIPTION
I thought the password field was a little wider than it needed to be, so I constrained it's size.

### Before

![image](https://github.com/user-attachments/assets/fe1d2509-823d-4ba8-9da7-4ce9484c8498)

### After

![image](https://github.com/user-attachments/assets/389d9c5b-00fb-4952-a1a1-de8d7ed21411)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the layout of the login form by setting a maximum width to improve visual presentation.
- **Bug Fixes**
	- No bug fixes were made; error handling logic remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->