### PR TITLE
fix: replace broken discord link

### DIFF
--- a/apps/router/src/components/Footer.tsx
+++ b/apps/router/src/components/Footer.tsx
@@ -46,7 +46,7 @@ export const Footer = () => {
           href='https://fedimint.org'
         />
         <Flex direction='row' gap={4} justifyContent='center'>
-          <CustomLink title='Discord' href='https://discord.gg/nzqta7AZ' />
+          <CustomLink title='Discord' href='https://chat.fedimint.org/' />
           <CustomLink title='Github' href='https://github.com/fedimint' />
         </Flex>
       </Stack>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Discord link in the footer to direct users to the new chat platform at `https://chat.fedimint.org/`.

- **Bug Fixes**
	- Corrected the destination of the Discord link for improved user navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->