### PR TITLE
defaults gateway to msats on load

### DIFF
--- a/apps/router/src/gateway-ui/components/HeaderWithUnitSelector.tsx
+++ b/apps/router/src/gateway-ui/components/HeaderWithUnitSelector.tsx
@@ -27,7 +27,7 @@ export const HeaderWithUnitSelector: React.FC = () => {
       <Tabs
         size='sm'
         variant='soft-rounded'
-        defaultIndex={1}
+        defaultIndex={0}
         onChange={(index) => {
           dispatch({
             type: GATEWAY_APP_ACTION_TYPE.SET_UNIT,


### PR DESCRIPTION
builds on fix PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced display of active service information in the header.
	- Default tab selection changed to the first tab in the unit selector.

- **Bug Fixes**
	- Improved error handling in active service retrieval, now returning `null` for invalid types instead of throwing errors.

- **Chores**
	- Updated `fedimint` input to version `v0.4.2` for improved stability and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->