### PR TITLE
fix: NixOS package build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN yarn build
 FROM base AS runner
 WORKDIR /app
 
+# note: remember to make changes to the installPhase in flake.nix as well
 COPY --from=installer /app/apps/router/build build
 COPY scripts/replace-react-env.js scripts/replace-react-env.js
 COPY scripts/write-config-from-env.js scripts/write-config-from-env.js

--- a/flake.lock
+++ b/flake.lock
@@ -119,17 +119,17 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1727712199,
-        "narHash": "sha256-3Y95+vA64HaqodepPkwY159vIc6JES5oo9qPWLRF9es=",
+        "lastModified": 1727317398,
+        "narHash": "sha256-NUr1ZpYJozWIej46Oqlf/7feJ4kztYYvX3TEzQ5VoWo=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "e8e3e6d84c223c3b90d7cf8d5fd5f346a7443e66",
+        "rev": "1813069d5d18a29f611a423990e8013a7331d2a2",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
+        "ref": "refs/tags/v0.4.3",
         "repo": "fedimint",
-        "rev": "e8e3e6d84c223c3b90d7cf8d5fd5f346a7443e66",
         "type": "github"
       }
     },


### PR DESCRIPTION
This PR includes essential updates to ensure the Nix build process remains consistent and reliable.

1. **Update `yarnOfflineCache` Hash in `flake.nix`**
   -  Updated the SHA-256 hash to align with the latest `yarn.lock` changes.
   -  Fixes build failures caused by hash mismatches between `flake.nix` and `yarn.lock`.

2. **Fix `buildPhase` and `installPhase`**
   - Corrected the `buildPhase` to use existing Yarn command.
   - Adjusted the `installPhase` to properly copy files in line with the Docker configuration.

3. **Use `fedimint` Release Version**
   -  Replaced the `fedimint` input commit hash with a stable release version.
   -  Ensures Nix uses released versions of `fedimint` for stability, avoiding dependencies on development commits.

Closes [#534](https://github.com/fedimint/ui/issues/534)
