### PR TITLE
Implement trimming of leading/trailing whitespace and newlines for verification codes

### DIFF
--- a/apps/router/src/guardian-ui/components/setup/screens/verifyGuardians/VerifyGuardians.tsx
+++ b/apps/router/src/guardian-ui/components/setup/screens/verifyGuardians/VerifyGuardians.tsx
@@ -42,6 +42,7 @@ import {
   useGuardianSetupContext,
   useTrimmedInputArray,
 } from '../../../../../hooks';
+import { useTrimmedInputArray } from '../../../../../hooks';
 
 interface PeerWithHash {
   id: string;
@@ -75,6 +76,9 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
 
   // Poll for peers and configGenParams while on this page.
   useConsensusPolling();
+
+  const [enteredHashes, handleHashChange, setEnteredHashes] =
+    useTrimmedInputArray(peersWithHash ? peersWithHash.map(() => '') : []);
 
   useEffect(() => {
     async function assembleHashInfo() {

--- a/apps/router/src/guardian-ui/components/setup/screens/verifyGuardians/VerifyGuardians.tsx
+++ b/apps/router/src/guardian-ui/components/setup/screens/verifyGuardians/VerifyGuardians.tsx
@@ -42,7 +42,6 @@ import {
   useGuardianSetupContext,
   useTrimmedInputArray,
 } from '../../../../../hooks';
-import { useTrimmedInputArray } from '../../../../../hooks';
 
 interface PeerWithHash {
   id: string;
@@ -76,9 +75,6 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
 
   // Poll for peers and configGenParams while on this page.
   useConsensusPolling();
-
-  const [enteredHashes, handleHashChange, setEnteredHashes] =
-    useTrimmedInputArray(peersWithHash ? peersWithHash.map(() => '') : []);
 
   useEffect(() => {
     async function assembleHashInfo() {

--- a/apps/router/src/guardian-ui/components/setup/screens/verifyGuardians/VerifyGuardians.tsx
+++ b/apps/router/src/guardian-ui/components/setup/screens/verifyGuardians/VerifyGuardians.tsx
@@ -64,9 +64,8 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
   const isHost = role === GuardianRole.Host;
   const [myHash, setMyHash] = useState('');
   const [peersWithHash, setPeersWithHash] = useState<PeerWithHash[]>();
-  const [enteredHashes, handleHashChange] = useTrimmedInputArray(
-    peersWithHash ? peersWithHash.map(() => '') : []
-  );
+  const { values: enteredHashes, handleChange: handleHashChange } =
+    useTrimmedInputArray(peersWithHash ? peersWithHash.map(() => '') : []);
   const [verifiedConfigs, setVerifiedConfigs] = useState<boolean>(false);
   const [isStarting, setIsStarting] = useState(false);
   const [error, setError] = useState<string>();

--- a/apps/router/src/hooks/custom/useTrimmedInput.tsx
+++ b/apps/router/src/hooks/custom/useTrimmedInput.tsx
@@ -23,5 +23,5 @@ export const useTrimmedInputArray = (initialValues: string[]) => {
     });
   }, []);
 
-  return [values, handleChange] as const;
+  return { values, handleChange };
 };

--- a/apps/router/src/hooks/custom/useTrimmedInput.tsx
+++ b/apps/router/src/hooks/custom/useTrimmedInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 const cleanInput = (value: string | undefined) => value?.trim() ?? '';
 
@@ -15,13 +15,13 @@ export const useTrimmedInput = (initialValue = '') => {
 export const useTrimmedInputArray = (initialValues: string[]) => {
   const [values, setValues] = useState<string[]>(initialValues);
 
-  const handleChange = (index: number, newValue: string) => {
+  const handleChange = useCallback((index: number, newValue: string) => {
     setValues((prev) => {
       const newValues = [...prev];
       newValues[index] = cleanInput(newValue);
       return newValues;
     });
-  };
+  }, []);
 
   return [values, handleChange] as const;
 };

--- a/apps/router/src/hooks/index.tsx
+++ b/apps/router/src/hooks/index.tsx
@@ -3,14 +3,7 @@ import { useLocation } from 'react-router-dom';
 export * from './guardian/useGuardian';
 export * from './guardian/useGuardianSetup';
 export * from './gateway/useGateway';
-<<<<<<< HEAD
 export * from './custom/useTrimmedInput';
-=======
-export {
-  useTrimmedInput,
-  useTrimmedInputArray,
-} from './custom/useTrimmedInput';
->>>>>>> d42ce8a9 (feat: trim whitespace in verification codes)
 
 import { useContext } from 'react';
 import { AppContext, AppContextValue } from '../context/AppContext';

--- a/apps/router/src/hooks/index.tsx
+++ b/apps/router/src/hooks/index.tsx
@@ -3,7 +3,14 @@ import { useLocation } from 'react-router-dom';
 export * from './guardian/useGuardian';
 export * from './guardian/useGuardianSetup';
 export * from './gateway/useGateway';
+<<<<<<< HEAD
 export * from './custom/useTrimmedInput';
+=======
+export {
+  useTrimmedInput,
+  useTrimmedInputArray,
+} from './custom/useTrimmedInput';
+>>>>>>> d42ce8a9 (feat: trim whitespace in verification codes)
 
 import { useContext } from 'react';
 import { AppContext, AppContextValue } from '../context/AppContext';


### PR DESCRIPTION
Issue #585 

### **Implementation Summary**

**Objective**: Implement a hook to trim leading and trailing whitespace from verification codes, improving user input validation and enhancing the overall experience during setup.

---

### **Key Changes**

1. **Custom Hook `useTrimmedInputArray`**:  
   - Created in `ui/apps/router/src/hooks/custom/useTrimmedInput.tsx`.  
   - Manages multiple inputs, automatically removing spaces at the start and end of each entry.  

2. **Updated Components**:  
   - **`VerifyGuardians.tsx`**: Integrated `useTrimmedInputArray` to sanitize the verification codes entered by guardians.  

---

### **Features**

- Automatic trimming of whitespace during input or paste operations.  
- Enhanced user experience by reducing input validation errors.  
- Promotes cleaner and reusable code with the new custom hook.

---

### **Before and Now**

- **Before**: Input handling lacked automatic sanitization, leading to validation errors caused by whitespace.  
- **Now**: `useTrimmedInputArray` ensures all inputs are sanitized automatically, improving robustness and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated state management in the `VerifyGuardians` component to use a more optimized hook for input handling
	- Improved performance of input change handling by utilizing `useCallback` in the custom input hook
<!-- end of auto-generated comment: release notes by coderabbit.ai -->