### PR TITLE
Trim passwords input

### DIFF
--- a/apps/router/src/guardian-ui/components/setup/screens/setConfiguration/ConfirmPasswordModal.tsx
+++ b/apps/router/src/guardian-ui/components/setup/screens/setConfiguration/ConfirmPasswordModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Alert,
   AlertDescription,
@@ -21,6 +21,7 @@ import {
 } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
 import { ReactComponent as WarningIcon } from '../../../../assets/svgs/warning.svg';
+import { useTrimmedInput } from '../../../../../hooks';
 
 interface ConfirmPasswordModalProps {
   password: string;
@@ -38,8 +39,8 @@ export const ConfirmPasswordModal: React.FC<ConfirmPasswordModalProps> = ({
   guardianName,
 }) => {
   const { t } = useTranslation();
-  const [confirmPassword, setConfirmPassword] = useState('');
-  const [confirmGuardianName, setConfirmGuardianName] = useState('');
+  const [confirmPassword, setConfirmPassword] = useTrimmedInput('');
+  const [confirmGuardianName, setConfirmGuardianName] = useTrimmedInput('');
 
   const confirmed =
     confirmPassword === password && confirmGuardianName === guardianName;

--- a/apps/router/src/hooks/custom/useTrimmedInput.tsx
+++ b/apps/router/src/hooks/custom/useTrimmedInput.tsx
@@ -2,16 +2,6 @@ import { useState } from 'react';
 
 const cleanInput = (value: string) => value.trim();
 
-export const useTrimmedInput = (initialValue: string) => {
-  const [value, setValue] = useState(initialValue);
-
-  const handleChange = (newValue: string) => {
-    setValue(cleanInput(newValue));
-  };
-
-  return [value, handleChange] as const;
-};
-
 export const useTrimmedInputArray = (initialValues: string[]) => {
   const [values, setValues] = useState<string[]>(initialValues);
 
@@ -23,9 +13,5 @@ export const useTrimmedInputArray = (initialValues: string[]) => {
     });
   };
 
-  const setAllValues = (newValues: string[]) => {
-    setValues(newValues.map(cleanInput));
-  };
-
-  return [values, handleChange, setAllValues] as const;
+  return [values, handleChange] as const;
 };

--- a/apps/router/src/hooks/custom/useTrimmedInput.tsx
+++ b/apps/router/src/hooks/custom/useTrimmedInput.tsx
@@ -2,6 +2,16 @@ import { useState } from 'react';
 
 const cleanInput = (value: string) => value.trim();
 
+export const useTrimmedInput = (initialValue = '') => {
+  const [value, setValue] = useState(initialValue);
+
+  const handleChange = (newValue: string) => {
+    setValue(cleanInput(newValue));
+  };
+
+  return [value, handleChange] as const;
+};
+
 export const useTrimmedInputArray = (initialValues: string[]) => {
   const [values, setValues] = useState<string[]>(initialValues);
 

--- a/apps/router/src/hooks/custom/useTrimmedInput.tsx
+++ b/apps/router/src/hooks/custom/useTrimmedInput.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+const cleanInput = (value: string) => value.trim();
+
+export const useTrimmedInput = (initialValue: string) => {
+  const [value, setValue] = useState(initialValue);
+
+  const handleChange = (newValue: string) => {
+    setValue(cleanInput(newValue));
+  };
+
+  return [value, handleChange] as const;
+};
+
+export const useTrimmedInputArray = (initialValues: string[]) => {
+  const [values, setValues] = useState<string[]>(initialValues);
+
+  const handleChange = (index: number, newValue: string) => {
+    setValues((prev) => {
+      const newValues = [...prev];
+      newValues[index] = cleanInput(newValue);
+      return newValues;
+    });
+  };
+
+  const setAllValues = (newValues: string[]) => {
+    setValues(newValues.map(cleanInput));
+  };
+
+  return [values, handleChange, setAllValues] as const;
+};

--- a/apps/router/src/hooks/index.tsx
+++ b/apps/router/src/hooks/index.tsx
@@ -3,6 +3,10 @@ import { useLocation } from 'react-router-dom';
 export * from './guardian/useGuardian';
 export * from './guardian/useGuardianSetup';
 export * from './gateway/useGateway';
+export {
+  useTrimmedInput,
+  useTrimmedInputArray,
+} from './custom/useTrimmedInput';
 
 import { useContext } from 'react';
 import { AppContext, AppContextValue } from '../context/AppContext';

--- a/apps/router/src/hooks/index.tsx
+++ b/apps/router/src/hooks/index.tsx
@@ -3,10 +3,7 @@ import { useLocation } from 'react-router-dom';
 export * from './guardian/useGuardian';
 export * from './guardian/useGuardianSetup';
 export * from './gateway/useGateway';
-export {
-  useTrimmedInput,
-  useTrimmedInputArray,
-} from './custom/useTrimmedInput';
+export * from './custom/useTrimmedInput';
 
 import { useContext } from 'react';
 import { AppContext, AppContextValue } from '../context/AppContext';


### PR DESCRIPTION
Issue #573 

### Implementation Summary

**Objective:** Improve input handling by trimming unnecessary whitespace from passwords and guardian names during confirmation, enhancing user experience and reducing errors.

---

### Key Changes

- **Hooks in `useTrimmedInput.tsx`:** The `useTrimmedInput` hook was reused and adapted to handle password inputs, ensuring that whitespace is trimmed automatically to reduce validation errors.

---

### Features

- **Automatic Whitespace Removal:** Trims leading and trailing spaces during input to avoid validation errors.
- **Error Reduction:** Prevents issues caused by unintentional whitespace in passwords or guardian names.
- **Consistency:** Ensures uniform input sanitization across the application.

---

### UI Implementation

- **Before:** Manual input management (`useState`) lacked automatic trimming.
- **Now:** `useTrimmedInput` automatically sanitizes inputs, simplifying validation and enhancing usability.



https://github.com/user-attachments/assets/5b54d007-7fa4-4204-bdf4-7d1b55731b05

