### PR TITLE
Fix missing translations

### DIFF
--- a/apps/router/src/home/NoConnectedServices.tsx
+++ b/apps/router/src/home/NoConnectedServices.tsx
@@ -18,11 +18,11 @@ export const NoConnectedServices: React.FC = () => {
         <Text fontSize='xl' fontWeight='bold' textAlign='center'>
           {t('router.title', 'No services connected yet.')}
         </Text>
-        <Text>{t('router.services-title')}</Text>
+        <Text>{t('router.services-description')}</Text>
         <UnorderedList spacing={4} paddingLeft={6}>
           <ListItem>
             <Text fontWeight='bold'>{t('router.guardians')}</Text>
-            <Text>{t('router.services-description')}</Text>
+            <Text>{t('router.guardians-description')}</Text>
           </ListItem>
           <ListItem>
             <Text fontWeight='bold'>{t('router.gateways')}</Text>

--- a/apps/router/src/languages/en.json
+++ b/apps/router/src/languages/en.json
@@ -37,8 +37,9 @@
   },
   "router": {
     "title": "No services connected yet.",
-    "services-title": "A Fedimint federation consists of two types of services:",
-    "services-description": "Responsible for running the Fedimint protocol, custodying funds, and managing the minting and redemption of eCash notes. They use distributed consensus to secure the federation.",
+    "services-description": "A Fedimint federation consists of two types of services:",
+    "guardians": "Guardians:",
+    "guardians-description": "Responsible for running the Fedimint protocol, custodying funds, and managing the minting and redemption of eCash notes. They use distributed consensus to secure the federation.",
     "gateways": "Gateways (Lightning Service Providers):",
     "gateways-description": "Bridge between the Fedimint and the Lightning Network, allowing users to send and receive Lightning payments. They can be run by the federation or independent providers.",
     "learn-more": "You can learn more about how to set up Fedimint services here:",


### PR DESCRIPTION
This PR adds a couple of missing translations in the `NoConnectedServices` page.

![Screenshot 2025-01-20 at 20 53 04](https://github.com/user-attachments/assets/8d8e5f2d-37dd-467f-ae63-991dd9638833)
