### PR TITLE
Add Basic Test Setup

### DIFF
--- a/apps/router/package.json
+++ b/apps/router/package.json
@@ -6,7 +6,8 @@
     "start": "react-scripts start",
     "dev": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false --transformIgnorePatterns \"node_modules/(?!jsonrpc-client-websocket)/\"",
+    "test:watch": "react-scripts test --transformIgnorePatterns \"node_modules/(?!jsonrpc-client-websocket)/\"",
     "eject": "react-scripts eject",
     "lint": "eslint \"src/**/*.ts*\" --max-warnings 0",
     "clean": "rm -rf build"

--- a/apps/router/src/App.test.tsx
+++ b/apps/router/src/App.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen, waitFor } from './utils/testing/customRender';
+import '@testing-library/jest-dom';
+import App from './App';
+
+// Mock react router dom
+const mockedNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Navigate: () => mockedNavigate(),
+}));
+
+// Mock AppContext
+const mockedDispatch = jest.fn();
+jest.mock('./hooks', () => ({
+  ...jest.requireActual('./hooks'),
+  useAppContext: () => ({
+    guardians: {},
+    gateways: {},
+    dispatch: mockedDispatch,
+  }),
+}));
+
+// Mock sha256Hash
+jest.mock('@fedimint/utils', () => ({
+  ...jest.requireActual('@fedimint/utils'),
+  sha256Hash: () => 'dummy-hash-value',
+}));
+
+describe('App', () => {
+  describe('Without env vars', () => {
+    it('should render the NoConnectedServices page', () => {
+      render(<App />);
+      const title = screen.getByText('No services connected yet.');
+      expect(title).toBeInTheDocument();
+    });
+  });
+
+  describe('With guardian env var', () => {
+    const OLD_ENV = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env.REACT_APP_FM_CONFIG_API = 'wss://guardian.com';
+    });
+
+    afterAll(() => {
+      process.env = OLD_ENV; // restore
+    });
+
+    it('should call dispatch and navigate', async () => {
+      render(<App />);
+
+      await waitFor(() => {
+        expect(mockedDispatch).toBeCalledTimes(1);
+        expect(mockedNavigate).toBeCalledTimes(1);
+      });
+    });
+  });
+
+  describe('With gateway env var', () => {
+    const OLD_ENV = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env.REACT_APP_FM_GATEWAY_API = 'https://gateway.com';
+    });
+
+    afterAll(() => {
+      process.env = OLD_ENV; // restore
+    });
+
+    it('should call dispatch and navigate', async () => {
+      render(<App />);
+
+      await waitFor(() => {
+        expect(mockedDispatch).toBeCalledTimes(1);
+        expect(mockedNavigate).toBeCalledTimes(1);
+      });
+    });
+  });
+});

--- a/apps/router/src/App.test.tsx
+++ b/apps/router/src/App.test.tsx
@@ -44,7 +44,7 @@ describe('App', () => {
       process.env.REACT_APP_FM_CONFIG_API = 'wss://guardian.com';
     });
 
-    afterAll(() => {
+    afterEach(() => {
       process.env = OLD_ENV; // restore
     });
 
@@ -66,7 +66,7 @@ describe('App', () => {
       process.env.REACT_APP_FM_GATEWAY_API = 'https://gateway.com';
     });
 
-    afterAll(() => {
+    afterEach(() => {
       process.env = OLD_ENV; // restore
     });
 

--- a/apps/router/src/App.test.tsx
+++ b/apps/router/src/App.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from './utils/testing/customRender';
 import '@testing-library/jest-dom';
 import App from './App';
+import { APP_ACTION_TYPE } from './context/AppContext';
 
 // Mock react router dom
 const mockedNavigate = jest.fn();
@@ -37,7 +38,7 @@ describe('App', () => {
   });
 
   describe('With guardian env var', () => {
-    const OLD_ENV = process.env;
+    const OLD_ENV = { ...process.env };
 
     beforeEach(() => {
       jest.resetModules();
@@ -46,20 +47,32 @@ describe('App', () => {
 
     afterEach(() => {
       process.env = OLD_ENV; // restore
+      jest.clearAllMocks();
     });
 
     it('should call dispatch and navigate', async () => {
       render(<App />);
 
       await waitFor(() => {
-        expect(mockedDispatch).toBeCalledTimes(1);
+        expect(mockedDispatch).toBeCalledWith({
+          type: APP_ACTION_TYPE.ADD_GUARDIAN,
+          payload: {
+            id: 'dummy-hash-value',
+            guardian: {
+              config: {
+                id: 'dummy-hash-value',
+                baseUrl: 'wss://guardian.com',
+              },
+            },
+          },
+        });
         expect(mockedNavigate).toBeCalledTimes(1);
       });
     });
   });
 
   describe('With gateway env var', () => {
-    const OLD_ENV = process.env;
+    const OLD_ENV = { ...process.env };
 
     beforeEach(() => {
       jest.resetModules();
@@ -74,7 +87,18 @@ describe('App', () => {
       render(<App />);
 
       await waitFor(() => {
-        expect(mockedDispatch).toBeCalledTimes(1);
+        expect(mockedDispatch).toBeCalledWith({
+          type: APP_ACTION_TYPE.ADD_GATEWAY,
+          payload: {
+            id: 'dummy-hash-value',
+            gateway: {
+              config: {
+                id: 'dummy-hash-value',
+                baseUrl: 'https://gateway.com',
+              },
+            },
+          },
+        });
         expect(mockedNavigate).toBeCalledTimes(1);
       });
     });

--- a/apps/router/src/App.tsx
+++ b/apps/router/src/App.tsx
@@ -1,0 +1,102 @@
+import React, { useState, useEffect } from 'react';
+import {
+  BrowserRouter as Router,
+  Route,
+  Routes,
+  Navigate,
+} from 'react-router-dom';
+import { Guardian } from './guardian-ui/Guardian';
+import { Gateway } from './gateway-ui/Gateway';
+import { sha256Hash } from '@fedimint/utils';
+import { APP_ACTION_TYPE } from './context/AppContext';
+import { HomePage } from './home/HomePage';
+import { GuardianContextProvider } from './context/guardian/GuardianContext';
+import { GatewayContextProvider } from './context/gateway/GatewayContext';
+import { Wrapper } from './components/Wrapper';
+import { useAppContext } from './hooks';
+
+export default function App() {
+  const { dispatch } = useAppContext();
+  const [redirectPath, setRedirectPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    const calculateRedirectPath = async () => {
+      if (process.env.REACT_APP_FM_CONFIG_API) {
+        try {
+          const hash = await sha256Hash(process.env.REACT_APP_FM_CONFIG_API);
+          dispatch({
+            type: APP_ACTION_TYPE.ADD_GUARDIAN,
+            payload: {
+              id: hash,
+              guardian: {
+                config: {
+                  id: hash,
+                  baseUrl: process.env.REACT_APP_FM_CONFIG_API,
+                },
+              },
+            },
+          });
+          setRedirectPath(`/guardian/${hash}`);
+        } catch (e) {
+          console.error(e);
+        }
+      } else if (process.env.REACT_APP_FM_GATEWAY_API) {
+        try {
+          const hash = await sha256Hash(process.env.REACT_APP_FM_GATEWAY_API);
+          dispatch({
+            type: APP_ACTION_TYPE.ADD_GATEWAY,
+            payload: {
+              id: hash,
+              gateway: {
+                config: {
+                  id: hash,
+                  baseUrl: process.env.REACT_APP_FM_GATEWAY_API,
+                },
+              },
+            },
+          });
+          setRedirectPath(`/gateway/${hash}`);
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    };
+
+    calculateRedirectPath();
+  }, [dispatch]);
+
+  return (
+    <Router>
+      <Wrapper>
+        <Routes>
+          <Route
+            path='/'
+            element={
+              redirectPath ? (
+                <Navigate to={redirectPath} replace />
+              ) : (
+                <HomePage />
+              )
+            }
+          />
+          <Route
+            path='/guardian/:id'
+            element={
+              <GuardianContextProvider>
+                <Guardian />
+              </GuardianContextProvider>
+            }
+          />
+          <Route
+            path='/gateway/:id'
+            element={
+              <GatewayContextProvider>
+                <Gateway />
+              </GatewayContextProvider>
+            }
+          />
+        </Routes>
+      </Wrapper>
+    </Router>
+  );
+}

--- a/apps/router/src/context/AppContext.tsx
+++ b/apps/router/src/context/AppContext.tsx
@@ -25,6 +25,12 @@ export interface AppContextValue {
   dispatch: Dispatch<AppAction>;
 }
 
+export const initialState: AppContextValue = {
+  guardians: {},
+  gateways: {},
+  dispatch: () => null,
+};
+
 const makeInitialState = (): AppContextValue => {
   const storedState = localStorage.getItem('fedimint_ui_state');
   if (storedState) {
@@ -38,11 +44,7 @@ const makeInitialState = (): AppContextValue => {
       console.error('Failed to parse stored state:', error);
     }
   }
-  return {
-    guardians: {},
-    gateways: {},
-    dispatch: () => null,
-  };
+  return initialState;
 };
 
 export enum APP_ACTION_TYPE {

--- a/apps/router/src/index.tsx
+++ b/apps/router/src/index.tsx
@@ -1,114 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom/client';
-import {
-  BrowserRouter as Router,
-  Route,
-  Routes,
-  Navigate,
-} from 'react-router-dom';
-import { Guardian } from './guardian-ui/Guardian';
-import { Gateway } from './gateway-ui/Gateway';
 import { Fonts, SharedChakraProvider, theme } from '@fedimint/ui';
 import spaceGroteskTtf from '@fedimint/ui/assets/fonts/SpaceGrotesk-Variable.ttf';
 import interTtf from '@fedimint/ui/assets/fonts/Inter-Variable.ttf';
 import { ColorModeScript } from '@chakra-ui/react';
-
-import { i18nProvider, sha256Hash } from '@fedimint/utils';
+import { i18nProvider } from '@fedimint/utils';
 import { languages } from './languages';
-import { APP_ACTION_TYPE, AppContextProvider } from './context/AppContext';
-import { HomePage } from './home/HomePage';
-import { GuardianContextProvider } from './context/guardian/GuardianContext';
-import { GatewayContextProvider } from './context/gateway/GatewayContext';
-import { Wrapper } from './components/Wrapper';
-import { useAppContext } from './hooks';
+import { AppContextProvider } from './context/AppContext';
+import App from './App';
 
 i18nProvider(languages);
-
-const App = () => {
-  const { dispatch } = useAppContext();
-  const [redirectPath, setRedirectPath] = useState<string | null>(null);
-
-  useEffect(() => {
-    const calculateRedirectPath = async () => {
-      if (process.env.REACT_APP_FM_CONFIG_API) {
-        try {
-          const hash = await sha256Hash(process.env.REACT_APP_FM_CONFIG_API);
-          dispatch({
-            type: APP_ACTION_TYPE.ADD_GUARDIAN,
-            payload: {
-              id: hash,
-              guardian: {
-                config: {
-                  id: hash,
-                  baseUrl: process.env.REACT_APP_FM_CONFIG_API,
-                },
-              },
-            },
-          });
-          setRedirectPath(`/guardian/${hash}`);
-        } catch (e) {
-          console.error(e);
-        }
-      } else if (process.env.REACT_APP_FM_GATEWAY_API) {
-        try {
-          const hash = await sha256Hash(process.env.REACT_APP_FM_GATEWAY_API);
-          dispatch({
-            type: APP_ACTION_TYPE.ADD_GATEWAY,
-            payload: {
-              id: hash,
-              gateway: {
-                config: {
-                  id: hash,
-                  baseUrl: process.env.REACT_APP_FM_GATEWAY_API,
-                },
-              },
-            },
-          });
-          setRedirectPath(`/gateway/${hash}`);
-        } catch (e) {
-          console.error(e);
-        }
-      }
-    };
-
-    calculateRedirectPath();
-  }, [dispatch]);
-
-  return (
-    <Router>
-      <Wrapper>
-        <Routes>
-          <Route
-            path='/'
-            element={
-              redirectPath ? (
-                <Navigate to={redirectPath} replace />
-              ) : (
-                <HomePage />
-              )
-            }
-          />
-          <Route
-            path='/guardian/:id'
-            element={
-              <GuardianContextProvider>
-                <Guardian />
-              </GuardianContextProvider>
-            }
-          />
-          <Route
-            path='/gateway/:id'
-            element={
-              <GatewayContextProvider>
-                <Gateway />
-              </GatewayContextProvider>
-            }
-          />
-        </Routes>
-      </Wrapper>
-    </Router>
-  );
-};
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/apps/router/src/setupTests.ts
+++ b/apps/router/src/setupTests.ts
@@ -1,0 +1,15 @@
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // Deprecated
+      removeListener: jest.fn(), // Deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});

--- a/apps/router/src/utils/testing/customRender.tsx
+++ b/apps/router/src/utils/testing/customRender.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react';
+import { render } from '@testing-library/react';
+import { SharedChakraProvider, theme } from '@fedimint/ui';
+import { i18nProvider } from '@fedimint/utils';
+import { languages } from '../../languages';
+import { AppContext, initialState } from '../../context/AppContext';
+
+i18nProvider(languages);
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <SharedChakraProvider theme={theme}>
+      <AppContext.Provider value={initialState}>{children}</AppContext.Provider>
+    </SharedChakraProvider>
+  );
+};
+
+const customRender = (ui: ReactElement) => render(ui, { wrapper: TestWrapper });
+
+export * from '@testing-library/react';
+export { customRender as render };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "test": "turbo run test",
+    "test:watch": "turbo run test:watch",
     "prepare": "husky install",
     "nix-guardian": "./scripts/mprocs-nix.sh run-ui mprocs-nix-guardian.yml",
     "nix-gateway": "./scripts/mprocs-nix.sh dev-fed mprocs-nix-gateway.yml",

--- a/turbo.json
+++ b/turbo.json
@@ -31,8 +31,10 @@
       ]
     },
     "test": {
-      "outputs": ["coverage/**"],
-      "dependsOn": []
+      "outputs": []
+    },
+    "test:watch": {
+      "cache": false
     },
     "lint": {
       "outputs": [],


### PR DESCRIPTION
This PR adds basic setup to allow unit tests to be run.

- Refactors `index.ts`
- Adds `App.ts` with test file
- Adds a custom render function that subsequent tests can make use of
- Separates `test` and `test:watch` scripts (so that tests can be run in pipeline in the future)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a new `test:watch` script for running tests in watch mode.
	- Introduced a custom rendering utility for testing React components.

- **Testing Improvements**
	- Enhanced test setup with mock implementations for `window.matchMedia`.
	- Established a comprehensive set of unit tests for the `App` component.
	- Improved test environment configuration.

- **Chores**
	- Refactored application routing and context management.
	- Updated project configuration files for better testing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->