### PR TITLE
Add Missing Translations

### DIFF
--- a/apps/router/src/home/NoConnectedServices.tsx
+++ b/apps/router/src/home/NoConnectedServices.tsx
@@ -18,11 +18,11 @@ export const NoConnectedServices: React.FC = () => {
         <Text fontSize='xl' fontWeight='bold' textAlign='center'>
           {t('router.title', 'No services connected yet.')}
         </Text>
-        <Text>{t('router.services-title')}</Text>
+        <Text>{t('router.services-description')}</Text>
         <UnorderedList spacing={4} paddingLeft={6}>
           <ListItem>
             <Text fontWeight='bold'>{t('router.guardians')}</Text>
-            <Text>{t('router.services-description')}</Text>
+            <Text>{t('router.guardians-description')}</Text>
           </ListItem>
           <ListItem>
             <Text fontWeight='bold'>{t('router.gateways')}</Text>

--- a/apps/router/src/languages/en.json
+++ b/apps/router/src/languages/en.json
@@ -37,8 +37,9 @@
   },
   "router": {
     "title": "No services connected yet.",
-    "services-title": "A Fedimint federation consists of two types of services:",
-    "services-description": "Responsible for running the Fedimint protocol, custodying funds, and managing the minting and redemption of eCash notes. They use distributed consensus to secure the federation.",
+    "services-description": "A Fedimint federation consists of two types of services:",
+    "guardians": "Guardians:",
+    "guardians-description": "Responsible for running the Fedimint protocol, custodying funds, and managing the minting and redemption of eCash notes. They use distributed consensus to secure the federation.",
     "gateways": "Gateways (Lightning Service Providers):",
     "gateways-description": "Bridge between the Fedimint and the Lightning Network, allowing users to send and receive Lightning payments. They can be run by the federation or independent providers.",
     "learn-more": "You can learn more about how to set up Fedimint services here:",


### PR DESCRIPTION
This PR fixes a missing translation on `NoConnectedServices` page and tweaks translation keys in `en.json`

**OLD**
![Screenshot 2025-01-23 at 21 15 46](https://github.com/user-attachments/assets/b2db7eea-c081-4f06-91a0-4fd47d56290e)

**NEW**
![Screenshot 2025-01-20 at 20 53 04](https://github.com/user-attachments/assets/89d16178-8269-4a1c-8414-abde19e8f7fe)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated localization strings to improve clarity about Fedimint federation services and guardian roles
  - Refined text descriptions for services and guardians in the English language configuration

- **Chores**
  - Removed and updated translation keys to enhance user understanding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->