### PR TITLE
Improve Connect Service Handler

### DIFF
--- a/apps/router/src/helpers/service.test.ts
+++ b/apps/router/src/helpers/service.test.ts
@@ -1,0 +1,35 @@
+import { getServiceType } from './service';
+
+describe('helpers/service', () => {
+  describe('when empty string is provided', () => {
+    it('should return null', () => {
+      const result = getServiceType('');
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('when invalid url is provided', () => {
+    it('should return null', () => {
+      const result = getServiceType('invalid-url');
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('when valid guardian url is provided', () => {
+    it('should return guardian', () => {
+      const result = getServiceType('wss://test-url.com');
+
+      expect(result).toBe('guardian');
+    });
+  });
+
+  describe('when valid gateway url is provided', () => {
+    it('should return gateway', () => {
+      const result = getServiceType('https://test-url.com');
+
+      expect(result).toBe('gateway');
+    });
+  });
+});

--- a/apps/router/src/helpers/service.ts
+++ b/apps/router/src/helpers/service.ts
@@ -1,15 +1,15 @@
-import { Service } from '../types';
+import { ServiceType } from '../types';
 
-export const getServiceType = (configUrl: string): Service | null => {
+export const getServiceType = (configUrl: string): ServiceType | null => {
   try {
     const url = new URL(configUrl);
 
     if (url.protocol.startsWith('ws')) {
-      return Service.Guardian;
+      return 'guardian';
     }
 
     if (url.protocol.startsWith('http')) {
-      return Service.Gateway;
+      return 'gateway';
     }
 
     return null;

--- a/apps/router/src/helpers/service.ts
+++ b/apps/router/src/helpers/service.ts
@@ -1,0 +1,19 @@
+import { Service } from '../types';
+
+export const getServiceType = (configUrl: string): Service | null => {
+  try {
+    const url = new URL(configUrl);
+
+    if (url.protocol.startsWith('ws')) {
+      return Service.Guardian;
+    }
+
+    if (url.protocol.startsWith('http')) {
+      return Service.Gateway;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+};

--- a/apps/router/src/home/ConnectServiceModal.tsx
+++ b/apps/router/src/home/ConnectServiceModal.tsx
@@ -19,7 +19,6 @@ import { sha256Hash, useTranslation } from '@fedimint/utils';
 import { useAppContext } from '../hooks';
 import { APP_ACTION_TYPE } from '../context/AppContext';
 import { getServiceType } from '../helpers/service';
-import { Service } from '../types';
 
 interface ConnectServiceModalProps {
   isOpen: boolean;
@@ -64,7 +63,7 @@ export const ConnectServiceModal: React.FC<ConnectServiceModalProps> = ({
       // helps to prevent user adding empty / invalid url
       if (!serviceType) return;
 
-      if (serviceType === Service.Guardian) {
+      if (serviceType === 'guardian') {
         dispatch({
           type: APP_ACTION_TYPE.ADD_GUARDIAN,
           payload: { id, guardian: { config: { id, baseUrl: configUrl } } },
@@ -75,6 +74,7 @@ export const ConnectServiceModal: React.FC<ConnectServiceModalProps> = ({
           payload: { id, gateway: { config: { id, baseUrl: configUrl } } },
         });
       }
+
       resetForm();
       onClose();
     } catch (error) {

--- a/apps/router/src/home/ConnectServiceModal.tsx
+++ b/apps/router/src/home/ConnectServiceModal.tsx
@@ -18,7 +18,8 @@ import {
 import { sha256Hash, useTranslation } from '@fedimint/utils';
 import { useAppContext } from '../hooks';
 import { APP_ACTION_TYPE } from '../context/AppContext';
-import { getServiceType } from './utils';
+import { getServiceType } from '../helpers/service';
+import { Service } from '../types';
 
 interface ConnectServiceModalProps {
   isOpen: boolean;
@@ -60,7 +61,10 @@ export const ConnectServiceModal: React.FC<ConnectServiceModalProps> = ({
       const id = await sha256Hash(configUrl);
       const serviceType = getServiceType(configUrl);
 
-      if (serviceType === 'guardian') {
+      // helps to prevent user adding empty / invalid url
+      if (!serviceType) return;
+
+      if (serviceType === Service.Guardian) {
         dispatch({
           type: APP_ACTION_TYPE.ADD_GUARDIAN,
           payload: { id, guardian: { config: { id, baseUrl: configUrl } } },

--- a/apps/router/src/home/utils.ts
+++ b/apps/router/src/home/utils.ts
@@ -9,9 +9,3 @@ export const checkServiceExists = (
     (s) => s.config.baseUrl === configUrl
   );
 };
-
-export const getServiceType = (configUrl: string): 'guardian' | 'gateway' => {
-  const isWebSocket =
-    configUrl.startsWith('ws://') || configUrl.startsWith('wss://');
-  return isWebSocket ? 'guardian' : 'gateway';
-};

--- a/apps/router/src/types/index.tsx
+++ b/apps/router/src/types/index.tsx
@@ -1,3 +1,9 @@
+export enum Service {
+  Guardian = 'guardian',
+  Gateway = 'gateway',
+}
+
+// Better to use enum above
 export type ServiceType = 'guardian' | 'gateway';
 
 export interface ServiceConfig {

--- a/apps/router/src/types/index.tsx
+++ b/apps/router/src/types/index.tsx
@@ -1,9 +1,3 @@
-export enum Service {
-  Guardian = 'guardian',
-  Gateway = 'gateway',
-}
-
-// Better to use enum above
 export type ServiceType = 'guardian' | 'gateway';
 
 export interface ServiceConfig {


### PR DESCRIPTION
This PR helps to prevent empty or invalid urls from being added in modal. Currently users can click Confirm regardless of what's in the input box.

![Screenshot 2025-01-24 at 11 00 39](https://github.com/user-attachments/assets/9128c0b8-1a6c-4f83-bac9-a7110334144b)

- Moves `getServiceType` to helper dir at a higher level so can be used in other areas of app if required
- Adds unit tests for new `getServiceType`
- Adds better typing for Guardian & Gateway types
- Adds logic to `onClick` handler in modal 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new function to determine service type based on URL configuration
	- Enhanced validation for service URL input in Connect Service Modal

- **Refactor**
	- Moved `getServiceType` function from `utils.ts` to `service.ts`
	- Updated import path for `getServiceType`

- **Tests**
	- Added comprehensive test suite for `getServiceType` function to validate different URL scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->