### PR TITLE
chore: add only-allow preinstall script to enforce yarn usage

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 auto-install-peers = true
+package-lock=false
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "turbo run lint",
     "test": "turbo run test",
     "test:watch": "turbo run test:watch",
+    "preinstall": "npx only-allow yarn",
     "prepare": "husky install",
     "nix-guardian": "./scripts/mprocs-nix.sh run-ui mprocs-nix-guardian.yml",
     "nix-gateway": "./scripts/mprocs-nix.sh dev-fed mprocs-nix-gateway.yml",


### PR DESCRIPTION
closes: #594

Now running `npm i` will throw an error and lockfiles won't be altered.
![image](https://github.com/user-attachments/assets/f20bdadc-2e67-4607-b6e7-6e653903b268)



