### PR TITLE
Update Modals (and Prevent New Gateway Creation)

### DIFF
--- a/apps/router/src/languages/en.json
+++ b/apps/router/src/languages/en.json
@@ -219,7 +219,9 @@
       "helper-text": "Will be wss:// for guardian or https:// for gateway",
       "service-type-label": "Service Type",
       "service-name-label": "Service Name",
-      "sync-status-label": "Sync Status"
+      "sync-status-label": "Sync Status",
+      "service-exists-error": "Service already exists",
+      "no-gateways-error": "Only Guardians can be added right now"
     },
     "remove-service-modal": {
       "title": "Remove {{type}}",

--- a/apps/router/src/modals/ConnectServiceModal.tsx
+++ b/apps/router/src/modals/ConnectServiceModal.tsx
@@ -10,6 +10,7 @@ import {
   ModalContent,
   ModalHeader,
   ModalOverlay,
+  ModalFooter,
   Text,
   Badge,
   Flex,
@@ -54,7 +55,7 @@ export const ConnectServiceModal: React.FC<ConnectServiceModalProps> = ({
     try {
       const exists = await checkServiceExists(configUrl);
       if (exists) {
-        throw new Error('Service already exists');
+        throw new Error(t('home.connect-service-modal.service-exists-error'));
       }
 
       const id = await sha256Hash(configUrl);
@@ -69,10 +70,13 @@ export const ConnectServiceModal: React.FC<ConnectServiceModalProps> = ({
           payload: { id, guardian: { config: { id, baseUrl: configUrl } } },
         });
       } else {
-        dispatch({
-          type: APP_ACTION_TYPE.ADD_GATEWAY,
-          payload: { id, gateway: { config: { id, baseUrl: configUrl } } },
-        });
+        // When Gateway UI is production ready, the dispatch can be reinstated
+        throw new Error(t('home.connect-service-modal.no-gateways-error'));
+
+        // dispatch({
+        //   type: APP_ACTION_TYPE.ADD_GATEWAY,
+        //   payload: { id, gateway: { config: { id, baseUrl: configUrl } } },
+        // });
       }
 
       resetForm();
@@ -84,7 +88,7 @@ export const ConnectServiceModal: React.FC<ConnectServiceModalProps> = ({
     } finally {
       setIsLoading(false);
     }
-  }, [configUrl, dispatch, resetForm, onClose, checkServiceExists]);
+  }, [configUrl, dispatch, resetForm, onClose, checkServiceExists, t]);
 
   return (
     <Modal
@@ -101,7 +105,7 @@ export const ConnectServiceModal: React.FC<ConnectServiceModalProps> = ({
           {t('home.connect-service-modal.title', 'Connect a Service')}
         </ModalHeader>
         <ModalCloseButton />
-        <ModalBody pb={6}>
+        <ModalBody>
           {error && (
             <Text color='red.500' mb={4}>
               {error}
@@ -120,15 +124,16 @@ export const ConnectServiceModal: React.FC<ConnectServiceModalProps> = ({
               }}
             />
           </FormControl>
+        </ModalBody>
+        <ModalFooter>
           <Button
-            mt={4}
             colorScheme='blue'
             onClick={handleConfirm}
             isLoading={isLoading}
           >
             {t('common.confirm')}
           </Button>
-        </ModalBody>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   );

--- a/apps/router/src/modals/EditServiceModal.tsx
+++ b/apps/router/src/modals/EditServiceModal.tsx
@@ -10,6 +10,7 @@ import {
   ModalContent,
   ModalHeader,
   ModalOverlay,
+  ModalFooter,
   useToast,
 } from '@chakra-ui/react';
 import { sha256Hash, useTranslation } from '@fedimint/utils';
@@ -103,7 +104,7 @@ export const EditServiceModal: React.FC<EditServiceModalProps> = ({
           })}
         </ModalHeader>
         <ModalCloseButton />
-        <ModalBody pb={6}>
+        <ModalBody>
           <FormControl>
             <FormLabel>{t('home.edit-service-modal.url-label')}</FormLabel>
             <Input
@@ -111,10 +112,12 @@ export const EditServiceModal: React.FC<EditServiceModalProps> = ({
               onChange={(e) => setConfigUrl(e.target.value)}
             />
           </FormControl>
-          <Button mt={4} colorScheme='blue' onClick={handleSubmit}>
+        </ModalBody>
+        <ModalFooter>
+          <Button colorScheme='blue' onClick={handleSubmit}>
             {t('common.save')}
           </Button>
-        </ModalBody>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   );


### PR DESCRIPTION
This PR makes the modals on the Home page more consistent.

Also, due to Gateway UI not being production ready, it offers a way to prevent new Gateways being added. (This is only a suggestion so please let me know if this approach is too heavy handed and you prefer a different approach). 

- Move action buttons on add, edit and delete service modals to the right hand side
- Make spacing consistent across add, edit and delete service modals
- Adds translation for new error message
- Adds translation for existing error message

**New Delete Service Modal**
![Screenshot 2025-02-05 at 19 59 51](https://github.com/user-attachments/assets/55ff525b-e531-4c2a-9cee-91dcb071fc3c)

**New Edit Service Modal**
![Screenshot 2025-02-05 at 19 41 35](https://github.com/user-attachments/assets/bb7a57b8-9292-4f06-8717-471faeec8642)

**New Add Service Modal**
![Screenshot 2025-02-05 at 19 41 54](https://github.com/user-attachments/assets/6afcc7d0-3911-4d5a-8136-cb1e789f433b)

**Add Service Modal (with error message)**
![Screenshot 2025-02-05 at 20 02 13](https://github.com/user-attachments/assets/dda447bd-c8a2-4bb9-b4a7-d70b3da75c6f)