### PR TITLE
Guardian authentication QR code missing password

### DIFF
--- a/apps/router/src/guardian-ui/admin/FederationAdmin.tsx
+++ b/apps/router/src/guardian-ui/admin/FederationAdmin.tsx
@@ -7,7 +7,7 @@ import {
 } from '@fedimint/types';
 import { FederationTabsCard } from '../components/dashboard/tabs/FederationTabsCard';
 import { DangerZone } from '../components/dashboard/danger/DangerZone';
-import { useGuardianAdminApi } from '../../hooks';
+import { useGuardianAdminApi, useGuardianApi } from '../../hooks';
 import { InviteCode } from '../components/dashboard/admin/InviteCode';
 import { useTranslation } from '@fedimint/utils';
 
@@ -21,6 +21,7 @@ const findOurPeerId = (
 export const FederationAdmin: React.FC = () => {
   const { t } = useTranslation();
   const api = useGuardianAdminApi();
+  const guardianApi = useGuardianApi();
 
   const [status, setStatus] = useState<StatusResponse>();
   const [inviteCode, setInviteCode] = useState<string>('');
@@ -131,6 +132,7 @@ export const FederationAdmin: React.FC = () => {
         ourPeer={ourPeer}
         latestSession={latestSession}
         signedApiAnnouncements={signedApiAnnouncements}
+        password={guardianApi.getPassword()}
       />
     </Flex>
   );

--- a/apps/router/src/guardian-ui/components/dashboard/danger/DangerZone.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/danger/DangerZone.tsx
@@ -14,6 +14,7 @@ interface DangerZoneProps {
   inviteCode: string;
   latestSession: number | undefined;
   signedApiAnnouncements: Record<string, SignedApiAnnouncement>;
+  password: string | null;
 }
 
 export const DangerZone: React.FC<DangerZoneProps> = ({
@@ -21,6 +22,7 @@ export const DangerZone: React.FC<DangerZoneProps> = ({
   inviteCode,
   latestSession,
   signedApiAnnouncements,
+  password,
 }) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -58,6 +60,7 @@ export const DangerZone: React.FC<DangerZoneProps> = ({
             <GuardianAuthenticationCode
               ourPeer={ourPeer}
               inviteCode={inviteCode}
+              password={password}
             />
           )}
           <DownloadBackup />

--- a/apps/router/src/guardian-ui/components/dashboard/danger/GuardianAuthenticationCode.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/danger/GuardianAuthenticationCode.tsx
@@ -27,11 +27,12 @@ type GuardianAuth = {
 interface GuardianAuthenticationCodeProps {
   inviteCode: string;
   ourPeer: { id: number; name: string };
+  password: string | null;
 }
 
 export const GuardianAuthenticationCode: React.FC<
   GuardianAuthenticationCodeProps
-> = ({ inviteCode, ourPeer }) => {
+> = ({ inviteCode, ourPeer, password }) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -45,7 +46,6 @@ export const GuardianAuthenticationCode: React.FC<
       name: ourPeer?.name,
     };
 
-    const password = sessionStorage.getItem('guardian-ui-key');
     if (password) {
       params.password = password;
     }


### PR DESCRIPTION
Issue #653 

### Problem
Guardian QR auth was failing because of a sessionStorage key mismatch - code was looking for `'guardian-ui-key'` but password was stored under the dynamic `serviceConfigId`.

### Solution
Discussed with @otech47 and went with prop-passing instead of fixing storage keys.

Flow: `useGuardianApi()` → `FederationAdmin` → `DangerZone` → `GuardianAuthenticationCode`

### Changes
- Pass password through props instead of sessionStorage lookup
- Remove storage dependency
- Update interfaces for type safety

### Testing
1. Set up guardian federation
2. Click "Authenticate as Guardian" 
3. Verify password appears in QR code


### Verification
Password successfully included in QR authentication params
<img width="2048" height="1211" alt="image" src="https://github.com/user-attachments/assets/f8f660ec-38af-40fb-a36b-08bdfb00f755" />
