### PR TITLE
chore: add password and url to guardian qr code

### DIFF
--- a/apps/router/src/guardian-ui/admin/FederationAdmin.tsx
+++ b/apps/router/src/guardian-ui/admin/FederationAdmin.tsx
@@ -7,7 +7,11 @@ import {
 } from '@fedimint/types';
 import { FederationTabsCard } from '../components/dashboard/tabs/FederationTabsCard';
 import { DangerZone } from '../components/dashboard/danger/DangerZone';
-import { useGuardianAdminApi } from '../../hooks';
+import {
+  useGuardianAdminApi,
+  useGuardianApi,
+  useGuardianConfig,
+} from '../../hooks';
 import { InviteCode } from '../components/dashboard/admin/InviteCode';
 import { useTranslation } from '@fedimint/utils';
 
@@ -20,7 +24,9 @@ const findOurPeerId = (
 
 export const FederationAdmin: React.FC = () => {
   const { t } = useTranslation();
-  const api = useGuardianAdminApi();
+  const adminApi = useGuardianAdminApi();
+  const guardianApi = useGuardianApi();
+  const guardianConfig = useGuardianConfig();
 
   const [status, setStatus] = useState<StatusResponse>();
   const [inviteCode, setInviteCode] = useState<string>('');
@@ -32,17 +38,20 @@ export const FederationAdmin: React.FC = () => {
   const [latestSession, setLatestSession] = useState<number>();
 
   const fetchData = useCallback(() => {
-    api.inviteCode().then(setInviteCode).catch(console.error);
-    api.config().then(setConfig).catch(console.error);
-    api.apiAnnouncements().then(setSignedApiAnnouncements).catch(console.error);
-    api
+    adminApi.inviteCode().then(setInviteCode).catch(console.error);
+    adminApi.config().then(setConfig).catch(console.error);
+    adminApi
+      .apiAnnouncements()
+      .then(setSignedApiAnnouncements)
+      .catch(console.error);
+    adminApi
       .status()
       .then((statusData) => {
         setStatus(statusData);
         setLatestSession(statusData?.federation?.session_count);
       })
       .catch(console.error);
-  }, [api]);
+  }, [adminApi]);
 
   useEffect(() => {
     fetchData();
@@ -127,10 +136,11 @@ export const FederationAdmin: React.FC = () => {
         />
       )}
       <DangerZone
-        inviteCode={inviteCode}
         ourPeer={ourPeer}
         latestSession={latestSession}
         signedApiAnnouncements={signedApiAnnouncements}
+        url={guardianConfig?.baseUrl}
+        password={guardianApi.getPassword()}
       />
     </Flex>
   );

--- a/apps/router/src/guardian-ui/components/dashboard/danger/DangerZone.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/danger/DangerZone.tsx
@@ -11,16 +11,18 @@ import { SignApiAnnouncement } from './SignApiAnnouncement';
 
 interface DangerZoneProps {
   ourPeer: { id: number; name: string } | undefined;
-  inviteCode: string;
   latestSession: number | undefined;
   signedApiAnnouncements: Record<string, SignedApiAnnouncement>;
+  url: string;
+  password: string | null;
 }
 
 export const DangerZone: React.FC<DangerZoneProps> = ({
   ourPeer,
-  inviteCode,
   latestSession,
   signedApiAnnouncements,
+  password,
+  url,
 }) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -57,7 +59,8 @@ export const DangerZone: React.FC<DangerZoneProps> = ({
           {ourPeer && (
             <GuardianAuthenticationCode
               ourPeer={ourPeer}
-              inviteCode={inviteCode}
+              password={password}
+              url={url}
             />
           )}
           <DownloadBackup />

--- a/apps/router/src/guardian-ui/components/dashboard/danger/GuardianAuthenticationCode.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/danger/GuardianAuthenticationCode.tsx
@@ -18,20 +18,21 @@ const QR_CODE_SIZE = 256;
 const FEDIMINT_GUARDIAN_PREFIX = 'fedimint:guardian:';
 
 type GuardianAuth = {
-  inviteCode: string;
   peerId: number;
   name: string;
-  password?: string;
+  url: string;
+  password: string | null;
 };
 
 interface GuardianAuthenticationCodeProps {
-  inviteCode: string;
   ourPeer: { id: number; name: string };
+  password: string | null;
+  url: string;
 }
 
 export const GuardianAuthenticationCode: React.FC<
   GuardianAuthenticationCodeProps
-> = ({ inviteCode, ourPeer }) => {
+> = ({ password, url, ourPeer }) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -40,15 +41,12 @@ export const GuardianAuthenticationCode: React.FC<
 
   const calculateGuardianAuthenticationCode = () => {
     const params: GuardianAuth = {
-      inviteCode: inviteCode,
       peerId: ourPeer?.id,
       name: ourPeer?.name,
+      url,
+      password,
     };
 
-    const password = sessionStorage.getItem('guardian-ui-key');
-    if (password) {
-      params.password = password;
-    }
     return `${FEDIMINT_GUARDIAN_PREFIX}${JSON.stringify(params)}`;
   };
 


### PR DESCRIPTION
ref #653 
Builds on #661

- Adds `password` and `url` to Guardian authentication qr code
- Removes `inviteCode` from DangerZone as not needed